### PR TITLE
Fix clang windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,19 @@ jobs:
         compiler: [msvc, clang]
         config: [Release, Debug]
         include:
+          - config: Debug
+            sccache: false
+            cmake_extra: ""
+          - config: Release
+            sccache: true
+            cmake_extra: -DCMAKE_CXX_COMPILER_LAUNCHER=sccache  
           - compiler: clang
-            cxx: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/Llvm/x64/bin/clang-cl.exe
-            cc: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/Llvm/x64/bin/clang-cl.exe
+            cxx: clang-cl
+            cc: clang-cl
             os: windows-2022
+            # disable cache in Windows with Clang
+            sscache: false
+            cmake_extra: ""
             vsvarsall: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
           - compiler: msvc
             cxx: cl
@@ -24,12 +33,6 @@ jobs:
             compiler: msvc
             os: windows-2019
             vsvarsall: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
-          - config: Debug
-            sccache: false
-            cmake_extra: ""
-          - config: Release
-            sccache: true
-            cmake_extra: -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
         exclude:
           - compiler: clang
             toolset: "14.1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,8 @@ jobs:
           sudo apt-get install -y ccache ninja-build ${{ matrix.compiler }}
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.14
+        with:
+          github-api-token: ${{ secrets.CMAKE_TOKEN }}
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.9
         with:
@@ -236,6 +238,8 @@ jobs:
            echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE" >> $GITHUB_ENV
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.14
+        with:
+          github-api-token: ${{ secrets.CMAKE_TOKEN }}
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.9
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
         config: [Release, Debug]
         include:
           - compiler: clang
-            cxx: clang-cl
-            cc: clang-cl
+            cxx: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/Llvm/x64/bin/clang-cl.exe
+            cc: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/Llvm/x64/bin/clang-cl.exe
             os: windows-2022
             vsvarsall: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
           - compiler: msvc
@@ -57,8 +57,8 @@ jobs:
           call "${{ matrix.vsvarsall }}" amd64 -vcvars_ver=${{ matrix.toolset }}
           cmake .. -GNinja ^
              -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" ^
-             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} ^
-             -DCMAKE_C_COMPILER=${{ matrix.cc }} ^
+             -DCMAKE_CXX_COMPILER="${{ matrix.cxx }}" ^
+             -DCMAKE_C_COMPILER="${{ matrix.cc }}" ^
              ${{ matrix.cmake_extra }} ^
              -DCMAKE_BUILD_TYPE=${{ matrix.config }} 
       - name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
             cxx: clang-cl
             cc: clang-cl
             os: windows-2022
-            # disable cache in Windows with Clang
-            sscache: "false"
+            # disable cache in Windows with Clang, as it fails compilation with latest compilers
+            sccache: "false"
             cmake_extra: ""
             vsvarsall: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
           - compiler: msvc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,17 @@ jobs:
         config: [Release, Debug]
         include:
           - config: Debug
-            sccache: false
+            sccache: "false"
             cmake_extra: ""
           - config: Release
-            sccache: true
+            sccache: "true"
             cmake_extra: -DCMAKE_CXX_COMPILER_LAUNCHER=sccache  
           - compiler: clang
             cxx: clang-cl
             cc: clang-cl
             os: windows-2022
             # disable cache in Windows with Clang
-            sscache: false
+            sscache: "false"
             cmake_extra: ""
             vsvarsall: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
           - compiler: msvc
@@ -47,7 +47,7 @@ jobs:
         run: |
           choco install -y ninja sccache
       - name: ccache
-        if: ${{ matrix.sccache }}
+        if: ${{ matrix.sccache == 'true' }}
         uses: hendrikmuhs/ccache-action@v1.2.9
         with:
           key: windows-${{ matrix.compiler }}-${{ matrix.toolset }}-${{ matrix.config }}

--- a/cmake/SetupTesting.cmake
+++ b/cmake/SetupTesting.cmake
@@ -76,6 +76,6 @@ function(xad_add_test name)
     xad_add_executable(${name} ${ARGN})
     target_link_libraries(${name} PRIVATE xad ${_gmock_target})
     set_property(TARGET ${name} PROPERTY FOLDER test)
-    gtest_discover_tests(${name} DISCOVERY_TIMEOUT 15)
+    gtest_discover_tests(${name} DISCOVERY_TIMEOUT 30)
 endfunction()
 


### PR DESCRIPTION
# Description

Recently, with later versions of Clang and Visual Studio being used in the latest github runner images, Clang builds on Windows began to fail while compiling Google Test. 

This PR fixes these issues - it was related to sccache not playing well together with the latest compilers. The fix was to disable the compiler cache with Clang on Windows entirely, resulting in slightly longer build times, but successful builds.

Further, it increases the test discovery timeout in CMake, as the test suite gets bigger and sometimes in Debug builds it takes longer to discover all the tests.

Fixes #60 

## Type of change

-   Bug fix (non-breaking change which fixes an issue)
