### PR TITLE
Fixing typo: R\&D -> R&D

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -40,7 +40,7 @@ For general questions about XAD, sharing ideas, engaging with community members,
 
 ## License Information
 
-Whether you are carrying out early stage R\&D, prototyping or large scale deployment, our flexible licensing options will meet your needs at every stage of the journey.
+Whether you are carrying out early stage R&D, prototyping or large scale deployment, our flexible licensing options will meet your needs at every stage of the journey.
 XAD allows anyone to get started with its AGPL license while Xcelerit provides commercial source-code licenses to support development and delivery of enterprise applications.
 
 Please [get in touch](https://www.xcelerit.com/xad-commercial) for commercial licensing and support options.


### PR DESCRIPTION
The about page in the website had an extra backslash in `R\&D` - this PR fixes this. 