### PR TITLE
Update tutorials link README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ XAD is a C++ library built with modern CMake and has no external dependencies.
 For instructions how to build and integrate it into your projects, please refer to the
 [Getting Started Guide](https://auto-differentiation.github.io/getting_started/).
 
-The documentation site also contains [tutorials](https://auto-differentiation.github.io/tutorials/), 
+The documentation site also contains [tutorials](https://auto-differentiation.github.io/tutorials/basic/), 
 [examples](https://auto-differentiation.github.io/examples/), 
 and information about [integrating XAD into QuantLib](https://auto-differentiation.github.io/quantlib/).
 


### PR DESCRIPTION
# Description

The previous link https://auto-differentiation.github.io/tutorials does not exist, there's no index page in that folder.
With this pull request, the README points to https://auto-differentiation.github.io/tutorials/basic, which is the same as the "Tutorials" button in the navigation menu on the documentation website.

As a side note, the link to the CLA in https://github.com/auto-differentiation/XAD/blob/f5652e85a927fb5dd7856902bfef6a0cfe0b5c34/CONTRIBUTING.md appears to be broken.

<!-- You can delete any part of this template that is not relevant to your submission -->

## Type of change

Please delete options that are not relevant.

-   Bug fix (non-breaking change which fixes an issue)
