### PR TITLE
Fix Clang build in Windows CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
             sccache: "true"
             cmake_extra: -DCMAKE_CXX_COMPILER_LAUNCHER=sccache  
           - compiler: clang
-            cxx: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/Llvm/bin/clang-cl.exe
-            cc: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/Llvm/bin/clang-cl.exe
+            cxx: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/Llvm/x64/bin/clang-cl.exe
+            cc: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/Llvm/x64/bin/clang-cl.exe
             os: windows-2022
             # disable cache in Windows with Clang, as it fails compilation with latest compilers
             sccache: "false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
             sccache: "true"
             cmake_extra: -DCMAKE_CXX_COMPILER_LAUNCHER=sccache  
           - compiler: clang
-            cxx: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC\Tools/Llvm/bin/clang-cl.exe
-            cc: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC\Tools/Llvm/bin/clang-cl.exe
+            cxx: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/Llvm/bin/clang-cl.exe
+            cc: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/Llvm/bin/clang-cl.exe
             os: windows-2022
             # disable cache in Windows with Clang, as it fails compilation with latest compilers
             sccache: "false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
             sccache: "true"
             cmake_extra: -DCMAKE_CXX_COMPILER_LAUNCHER=sccache  
           - compiler: clang
-            cxx: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\bin\clang-cl.exe
-            cc: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\bin\clang-cl.exe
+            cxx: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC\Tools/Llvm/bin/clang-cl.exe
+            cc: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC\Tools/Llvm/bin/clang-cl.exe
             os: windows-2022
             # disable cache in Windows with Clang, as it fails compilation with latest compilers
             sccache: "false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
             sccache: "true"
             cmake_extra: -DCMAKE_CXX_COMPILER_LAUNCHER=sccache  
           - compiler: clang
-            cxx: clang-cl
-            cc: clang-cl
+            cxx: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\bin\clang-cl.exe
+            cc: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\bin\clang-cl.exe
             os: windows-2022
             # disable cache in Windows with Clang, as it fails compilation with latest compilers
             sccache: "false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,8 @@ jobs:
           cd installtest
           call "${{ matrix.vsvarsall }}" amd64 -vcvars_ver=${{ matrix.toolset }}
           cmake ..\\samples -GNinja ^
-             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} ^
-             -DCMAKE_C_COMPILER=${{ matrix.cc }} ^
+             -DCMAKE_CXX_COMPILER="${{ matrix.cxx }}" ^
+             -DCMAKE_C_COMPILER="${{ matrix.cc }}" ^
              -DCMAKE_BUILD_TYPE=${{ matrix.config }} ^
              ${{ matrix.cmake_extra }} ^
              -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -370,7 +370,7 @@ or [submit a PR](https://github.com/auto-differentiation/XAD/blob/feature/new-si
 | Windows Server 2022 | Visual Studio 2017 (Toolset 14.1) | Debug, Release                                      | no                     |
 | Windows Server 2022 | Visual Studio 2019 (Toolset 14.2) | Debug, Release                                      | no                     |
 | Windows Server 2022 | Visual Studio 2022 (Toolset 14.3) | Debug, Release                                      | no                     |
-| Windows Server 2022 | Clang 15.0 (Toolset 14.3)         | Debug, Release                                      | no                     |
+| Windows Server 2022 | Clang 16.0 (Toolset 14.3)         | Debug, Release                                      | no                     |
 | Ubuntu 16.04        | GCC 5.4.0                         | Debug, Release, Release with `XAD_TAPE_REUSE_SLOTS` | no                     |
 | Ubuntu 17.10        | GCC 6.4.0                         | Debug, Release, Release with `XAD_TAPE_REUSE_SLOTS` | no                     |
 | Ubuntu 17.10        | GCC 7.2.0                         | Debug, Release, Release with `XAD_TAPE_REUSE_SLOTS` | no                     |


### PR DESCRIPTION
# Description

This fixes build failures recently occurring with the GitHub-supplied Windows runners when using Clang. Only passing `clang-cl` as compiler to CMake picks the version in the global LLVM install location, rather than the one that is shipped with Visual Studio. With the latest Visual Studio update, the globally installed version is no longer compatible.

The fix is to supply the absolute path to the Clang compilers to CMake.

