### PR TITLE
Adds complex arithmetics between XAD types and std::complex<double>

### DIFF
--- a/src/XAD/Complex.hpp
+++ b/src/XAD/Complex.hpp
@@ -609,10 +609,26 @@ XAD_INLINE std::complex<xad::AReal<T>> operator+(std::complex<xad::AReal<T>> lhs
 
 template <class T>
 XAD_INLINE std::complex<xad::AReal<T>> operator+(std::complex<xad::AReal<T>> lhs,
+                                                 const std::complex<T>& rhs)
+{
+    lhs += rhs;
+    return lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::AReal<T>> operator+(std::complex<xad::AReal<T>> lhs,
                                                  const xad::AReal<T>& rhs)
 {
     lhs += rhs;
     return lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::AReal<T>> operator+(std::complex<T> lhs, const xad::AReal<T>& rhs)
+{
+    std::complex<xad::AReal<T>> z = lhs;
+    z += rhs;
+    return z;
 }
 
 template <class T>
@@ -625,6 +641,23 @@ XAD_INLINE std::complex<xad::AReal<T>> operator+(std::complex<xad::AReal<T>> lhs
 template <class T, class Expr>
 XAD_INLINE std::complex<xad::AReal<T>> operator+(std::complex<xad::AReal<T>> lhs,
                                                  const xad::Expression<T, Expr>& rhs)
+{
+    lhs += rhs;
+    return lhs;
+}
+
+template <class T, class Expr>
+XAD_INLINE std::complex<typename xad::ExprTraits<Expr>::value_type> operator+(
+    const std::complex<T>& lhs, const xad::Expression<T, Expr>& rhs)
+{
+    std::complex<typename xad::ExprTraits<Expr>::value_type> z = lhs;
+    z += rhs;
+    return z;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::AReal<T>> operator+(const std::complex<T>& rhs,
+                                                 std::complex<xad::AReal<T>> lhs)
 {
     lhs += rhs;
     return lhs;
@@ -653,9 +686,34 @@ XAD_INLINE std::complex<xad::AReal<T>> operator+(const xad::Expression<T, Expr>&
     return lhs;
 }
 
+template <class T, class Expr>
+XAD_INLINE std::complex<typename xad::ExprTraits<Expr>::value_type> operator+(
+    const xad::Expression<T, Expr>& rhs, const std::complex<T>& lhs)
+{
+    std::complex<typename xad::ExprTraits<Expr>::value_type> z = lhs;
+    z += rhs;
+    return z;
+}
+
 template <class T>
 XAD_INLINE std::complex<xad::FReal<T>> operator+(std::complex<xad::FReal<T>> lhs,
                                                  const std::complex<xad::FReal<T>>& rhs)
+{
+    lhs += rhs;
+    return lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::FReal<T>> operator+(const std::complex<T>& lhs,
+                                                 std::complex<xad::FReal<T>> rhs)
+{
+    rhs += lhs;
+    return rhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::FReal<T>> operator+(std::complex<xad::FReal<T>> lhs,
+                                                 const std::complex<T>& rhs)
 {
     lhs += rhs;
     return lhs;
@@ -667,6 +725,15 @@ XAD_INLINE std::complex<xad::FReal<T>> operator+(std::complex<xad::FReal<T>> lhs
 {
     lhs += rhs;
     return lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::FReal<T>> operator+(const std::complex<T>& lhs,
+                                                 const xad::FReal<T>& rhs)
+{
+    std::complex<xad::FReal<T>> z = lhs;
+    z += rhs;
+    return z;
 }
 
 template <class T>
@@ -686,10 +753,19 @@ XAD_INLINE std::complex<xad::FReal<T>> operator+(std::complex<xad::FReal<T>> lhs
 
 template <class T>
 XAD_INLINE std::complex<xad::FReal<T>> operator+(const xad::FReal<T>& rhs,
-                                                 std::complex<xad::AReal<T>> lhs)
+                                                 std::complex<xad::FReal<T>> lhs)
 {
     lhs += rhs;
     return lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::FReal<T>> operator+(const xad::FReal<T>& rhs,
+                                                 const std::complex<T>& lhs)
+{
+    std::complex<xad::FReal<T>> z = lhs;
+    z += rhs;
+    return z;
 }
 
 template <class T>
@@ -719,10 +795,35 @@ XAD_INLINE std::complex<xad::AReal<T>> operator-(std::complex<xad::AReal<T>> lhs
 
 template <class T>
 XAD_INLINE std::complex<xad::AReal<T>> operator-(std::complex<xad::AReal<T>> lhs,
+                                                 const std::complex<T>& rhs)
+{
+    lhs -= rhs;
+    return lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::AReal<T>> operator-(const std::complex<T>& lhs,
+                                                 std::complex<xad::AReal<T>> rhs)
+{
+    std::complex<xad::AReal<T>> z = lhs;
+    z -= rhs;
+    return z;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::AReal<T>> operator-(std::complex<xad::AReal<T>> lhs,
                                                  const xad::AReal<T>& rhs)
 {
     lhs -= rhs;
     return lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::AReal<T>> operator-(std::complex<T> lhs, const xad::AReal<T>& rhs)
+{
+    std::complex<xad::AReal<T>> z = lhs;
+    z -= rhs;
+    return z;
 }
 
 template <class T>
@@ -738,6 +839,24 @@ XAD_INLINE std::complex<xad::AReal<T>> operator-(std::complex<xad::AReal<T>> lhs
 {
     lhs -= rhs;
     return lhs;
+}
+
+template <class T, class Expr>
+XAD_INLINE std::complex<typename xad::ExprTraits<Expr>::value_type> operator-(
+    const std::complex<T>& lhs, const xad::Expression<T, Expr>& rhs)
+{
+    std::complex<typename xad::ExprTraits<Expr>::value_type> z = lhs;
+    z -= rhs;
+    return z;
+}
+
+template <class T, class Expr>
+XAD_INLINE std::complex<typename xad::ExprTraits<Expr>::value_type> operator-(
+    const xad::Expression<T, Expr>& lhs, const std::complex<T>& rhs)
+{
+    std::complex<typename xad::ExprTraits<Expr>::value_type> z = lhs;
+    z -= rhs;
+    return z;
 }
 
 template <class T>
@@ -769,11 +888,37 @@ XAD_INLINE std::complex<xad::FReal<T>> operator-(std::complex<xad::FReal<T>> lhs
 }
 
 template <class T>
+XAD_INLINE std::complex<xad::FReal<T>> operator-(const std::complex<T>& lhs,
+                                                 const std::complex<xad::FReal<T>>& rhs)
+{
+    std::complex<xad::FReal<T>> z = lhs;
+    z -= rhs;
+    return z;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::FReal<T>> operator-(std::complex<xad::FReal<T>> lhs,
+                                                 const std::complex<T>& rhs)
+{
+    std::complex<xad::FReal<T>> z = rhs;
+    lhs -= z;
+    return lhs;
+}
+
+template <class T>
 XAD_INLINE std::complex<xad::FReal<T>> operator-(std::complex<xad::FReal<T>> lhs,
                                                  const xad::FReal<T>& rhs)
 {
     lhs -= rhs;
     return lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::FReal<T>> operator-(std::complex<T> lhs, const xad::FReal<T>& rhs)
+{
+    std::complex<xad::FReal<T>> z = lhs;
+    z -= rhs;
+    return z;
 }
 
 template <class T>
@@ -793,7 +938,13 @@ XAD_INLINE std::complex<xad::FReal<T>> operator-(std::complex<xad::FReal<T>> lhs
 
 template <class T>
 XAD_INLINE std::complex<xad::FReal<T>> operator-(const xad::FReal<T>& rhs,
-                                                 std::complex<xad::AReal<T>> lhs)
+                                                 std::complex<xad::FReal<T>> lhs)
+{
+    return std::complex<xad::FReal<T>>(rhs - lhs.real(), -lhs.imag());
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::FReal<T>> operator-(const xad::FReal<T>& rhs, std::complex<T> lhs)
 {
     return std::complex<xad::FReal<T>>(rhs - lhs.real(), -lhs.imag());
 }
@@ -822,10 +973,34 @@ XAD_INLINE std::complex<xad::AReal<T>> operator*(std::complex<xad::AReal<T>> lhs
 
 template <class T>
 XAD_INLINE std::complex<xad::AReal<T>> operator*(std::complex<xad::AReal<T>> lhs,
+                                                 const std::complex<T>& rhs)
+{
+    lhs *= rhs;
+    return lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::AReal<T>> operator*(const std::complex<T>& lhs,
+                                                 const std::complex<xad::AReal<T>>& rhs)
+{
+    return rhs * lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::AReal<T>> operator*(std::complex<xad::AReal<T>> lhs,
                                                  const xad::AReal<T>& rhs)
 {
     lhs *= rhs;
     return lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::AReal<T>> operator*(const std::complex<T>& lhs,
+                                                 const xad::AReal<T>& rhs)
+{
+    std::complex<xad::AReal<T>> z = lhs;
+    z *= rhs;
+    return z;
 }
 
 template <class T>
@@ -841,6 +1016,24 @@ XAD_INLINE std::complex<xad::AReal<T>> operator*(std::complex<xad::AReal<T>> lhs
 {
     lhs *= rhs;
     return lhs;
+}
+
+template <class T, class Expr>
+XAD_INLINE std::complex<typename xad::ExprTraits<Expr>::value_type> operator*(
+    const std::complex<T>& lhs, const xad::Expression<T, Expr>& rhs)
+{
+    std::complex<typename xad::ExprTraits<Expr>::value_type> z = lhs;
+    z *= rhs;
+    return z;
+}
+
+template <class T, class Expr>
+XAD_INLINE std::complex<typename xad::ExprTraits<Expr>::value_type> operator*(
+    const xad::Expression<T, Expr>& lhs, const std::complex<T>& rhs)
+{
+    std::complex<typename xad::ExprTraits<Expr>::value_type> z = lhs;
+    z *= rhs;
+    return z;
 }
 
 template <class T>
@@ -875,11 +1068,37 @@ XAD_INLINE std::complex<xad::FReal<T>> operator*(std::complex<xad::FReal<T>> lhs
 }
 
 template <class T>
+XAD_INLINE std::complex<xad::FReal<T>> operator*(const std::complex<T>& lhs,
+                                                 const std::complex<xad::FReal<T>>& rhs)
+{
+    std::complex<xad::FReal<T>> z = lhs;
+    z *= rhs;
+    return z;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::FReal<T>> operator*(std::complex<xad::FReal<T>> lhs,
+                                                 const std::complex<T>& rhs)
+{
+    std::complex<xad::FReal<T>> z = rhs;
+    lhs *= z;
+    return lhs;
+}
+
+template <class T>
 XAD_INLINE std::complex<xad::FReal<T>> operator*(std::complex<xad::FReal<T>> lhs,
                                                  const xad::FReal<T>& rhs)
 {
     lhs *= rhs;
     return lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::FReal<T>> operator*(std::complex<T> lhs, const xad::FReal<T>& rhs)
+{
+    std::complex<xad::FReal<T>> z = lhs;
+    z *= rhs;
+    return z;
 }
 
 template <class T>
@@ -899,10 +1118,18 @@ XAD_INLINE std::complex<xad::FReal<T>> operator*(std::complex<xad::FReal<T>> lhs
 
 template <class T>
 XAD_INLINE std::complex<xad::FReal<T>> operator*(const xad::FReal<T>& rhs,
-                                                 std::complex<xad::AReal<T>> lhs)
+                                                 std::complex<xad::FReal<T>> lhs)
 {
     lhs *= rhs;
     return lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::FReal<T>> operator*(const xad::FReal<T>& rhs, std::complex<T> lhs)
+{
+    std::complex<xad::FReal<T>> z = lhs;
+    z *= rhs;
+    return z;
 }
 
 template <class T>
@@ -920,7 +1147,7 @@ XAD_INLINE std::complex<xad::FReal<T>> operator*(const xad::Expression<T, Expr>&
     return lhs;
 }
 
-// operator-
+// operator/
 
 template <class T>
 XAD_INLINE std::complex<xad::AReal<T>> operator/(std::complex<xad::AReal<T>> lhs,
@@ -932,10 +1159,35 @@ XAD_INLINE std::complex<xad::AReal<T>> operator/(std::complex<xad::AReal<T>> lhs
 
 template <class T>
 XAD_INLINE std::complex<xad::AReal<T>> operator/(std::complex<xad::AReal<T>> lhs,
+                                                 const std::complex<T>& rhs)
+{
+    lhs /= rhs;
+    return lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::AReal<T>> operator/(const std::complex<T>& lhs,
+                                                 std::complex<xad::AReal<T>> rhs)
+{
+    std::complex<xad::AReal<T>> z = lhs;
+    z /= rhs;
+    return z;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::AReal<T>> operator/(std::complex<xad::AReal<T>> lhs,
                                                  const xad::AReal<T>& rhs)
 {
     lhs /= rhs;
     return lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::AReal<T>> operator/(std::complex<T> lhs, const xad::AReal<T>& rhs)
+{
+    std::complex<xad::AReal<T>> z = lhs;
+    z /= rhs;
+    return z;
 }
 
 template <class T>
@@ -951,6 +1203,24 @@ XAD_INLINE std::complex<xad::AReal<T>> operator/(std::complex<xad::AReal<T>> lhs
 {
     lhs /= rhs;
     return lhs;
+}
+
+template <class T, class Expr>
+XAD_INLINE std::complex<typename xad::ExprTraits<Expr>::value_type> operator/(
+    const std::complex<T>& lhs, const xad::Expression<T, Expr>& rhs)
+{
+    std::complex<typename xad::ExprTraits<Expr>::value_type> z = lhs;
+    z /= rhs;
+    return z;
+}
+
+template <class T, class Expr>
+XAD_INLINE std::complex<typename xad::ExprTraits<Expr>::value_type> operator/(
+    const xad::Expression<T, Expr>& lhs, const std::complex<T>& rhs)
+{
+    std::complex<typename xad::ExprTraits<Expr>::value_type> z = lhs;
+    z /= rhs;
+    return z;
 }
 
 template <class T>
@@ -982,11 +1252,37 @@ XAD_INLINE std::complex<xad::FReal<T>> operator/(std::complex<xad::FReal<T>> lhs
 }
 
 template <class T>
+XAD_INLINE std::complex<xad::FReal<T>> operator/(const std::complex<T>& lhs,
+                                                 const std::complex<xad::FReal<T>>& rhs)
+{
+    std::complex<xad::FReal<T>> z = lhs;
+    z /= rhs;
+    return z;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::FReal<T>> operator/(std::complex<xad::FReal<T>> lhs,
+                                                 const std::complex<T>& rhs)
+{
+    std::complex<xad::FReal<T>> z = rhs;
+    lhs /= z;
+    return lhs;
+}
+
+template <class T>
 XAD_INLINE std::complex<xad::FReal<T>> operator/(std::complex<xad::FReal<T>> lhs,
                                                  const xad::FReal<T>& rhs)
 {
     lhs /= rhs;
     return lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::FReal<T>> operator/(std::complex<T> lhs, const xad::FReal<T>& rhs)
+{
+    std::complex<xad::FReal<T>> z = lhs;
+    z /= rhs;
+    return z;
 }
 
 template <class T>
@@ -1006,7 +1302,13 @@ XAD_INLINE std::complex<xad::FReal<T>> operator/(std::complex<xad::FReal<T>> lhs
 
 template <class T>
 XAD_INLINE std::complex<xad::FReal<T>> operator/(const xad::FReal<T>& rhs,
-                                                 std::complex<xad::AReal<T>> lhs)
+                                                 std::complex<xad::FReal<T>> lhs)
+{
+    return std::complex<xad::FReal<T>>(rhs) / lhs;
+}
+
+template <class T>
+XAD_INLINE std::complex<xad::FReal<T>> operator/(const xad::FReal<T>& rhs, std::complex<T> lhs)
 {
     return std::complex<xad::FReal<T>>(rhs) / lhs;
 }

--- a/test/Complex_test.cpp
+++ b/test/Complex_test.cpp
@@ -844,9 +844,39 @@ TYPED_TEST(ComplexTest, AddComplex)
     EXPECT_THAT(xad::value(ret.imag()), DoubleNear(40.8, 1e-9));
 }
 
+TYPED_TEST(ComplexTest, AddComplexDouble)
+{
+    auto z1 = std::complex<TypeParam>(1.2, -1.2);
+    auto z2 = std::complex<double>(1.2, 42.0);
+    auto ret = z1 + z2;
+    EXPECT_THAT(xad::value(ret.real()), DoubleNear(2.4, 1e-9));
+    EXPECT_THAT(xad::value(ret.imag()), DoubleNear(40.8, 1e-9));
+}
+
+TYPED_TEST(ComplexTest, AddDoubleComplex)
+{
+    auto z1 = std::complex<double>(1.2, -1.2);
+    auto z2 = std::complex<TypeParam>(1.2, 42.0);
+    auto ret = z1 + z2;
+    EXPECT_THAT(xad::value(ret.real()), DoubleNear(2.4, 1e-9));
+    EXPECT_THAT(xad::value(ret.imag()), DoubleNear(40.8, 1e-9));
+}
+
 TYPED_TEST(ComplexTest, AddScalar)
 {
     auto z = std::complex<TypeParam>(1.2, -1.2);
+    TypeParam s = 1.2;
+    auto ret1 = z + s;
+    auto ret2 = s + z;
+    EXPECT_THAT(xad::value(ret1.real()), DoubleNear(2.4, 1e-9));
+    EXPECT_THAT(xad::value(ret1.imag()), DoubleNear(-1.2, 1e-9));
+    EXPECT_THAT(xad::value(ret2.real()), DoubleNear(2.4, 1e-9));
+    EXPECT_THAT(xad::value(ret2.imag()), DoubleNear(-1.2, 1e-9));
+}
+
+TYPED_TEST(ComplexTest, AddScalarDoubleCplx)
+{
+    auto z = std::complex<double>(1.2, -1.2);
     TypeParam s = 1.2;
     auto ret1 = z + s;
     auto ret2 = s + z;
@@ -860,24 +890,62 @@ TYPED_TEST(ComplexTest, AddScalarExpression)
 {
     auto z = std::complex<TypeParam>(1.2, -1.2);
     TypeParam s = 1.2;
-    std::complex<TypeParam> ret = z + (s * 1.0);
-    EXPECT_THAT(xad::value(ret.real()), DoubleNear(2.4, 1e-9));
-    EXPECT_THAT(xad::value(ret.imag()), DoubleNear(-1.2, 1e-9));
+    std::complex<TypeParam> ret1 = z + (s * 1.0);
+    std::complex<TypeParam> ret2 = (s * 1.0) + z;
+    EXPECT_THAT(xad::value(ret1.real()), DoubleNear(2.4, 1e-9));
+    EXPECT_THAT(xad::value(ret1.imag()), DoubleNear(-1.2, 1e-9));
+    EXPECT_THAT(xad::value(ret2.real()), DoubleNear(2.4, 1e-9));
+    EXPECT_THAT(xad::value(ret2.imag()), DoubleNear(-1.2, 1e-9));
+}
+
+TYPED_TEST(ComplexTest, AddScalarExpressionDoubleCplx)
+{
+    auto z = std::complex<double>(1.2, -1.2);
+    TypeParam s = 1.2;
+    std::complex<TypeParam> ret1 = z + (s * 1.0);
+    std::complex<TypeParam> ret2 = (s * 1.0) + z;
+    EXPECT_THAT(xad::value(ret1.real()), DoubleNear(2.4, 1e-9));
+    EXPECT_THAT(xad::value(ret1.imag()), DoubleNear(-1.2, 1e-9));
+    EXPECT_THAT(xad::value(ret2.real()), DoubleNear(2.4, 1e-9));
+    EXPECT_THAT(xad::value(ret2.imag()), DoubleNear(-1.2, 1e-9));
 }
 
 TYPED_TEST(ComplexTest, AddDouble)
 {
     auto z = std::complex<TypeParam>(1.2, -1.2);
-    std::complex<TypeParam> ret = z + 1.2;
-    EXPECT_THAT(xad::value(ret.real()), DoubleNear(2.4, 1e-9));
-    EXPECT_THAT(xad::value(ret.imag()), DoubleNear(-1.2, 1e-9));
+    std::complex<TypeParam> ret1 = z + 1.2;
+    std::complex<TypeParam> ret2 = 1.2 + z;
+    EXPECT_THAT(xad::value(ret1.real()), DoubleNear(2.4, 1e-9));
+    EXPECT_THAT(xad::value(ret1.imag()), DoubleNear(-1.2, 1e-9));
+    EXPECT_THAT(xad::value(ret2.real()), DoubleNear(2.4, 1e-9));
+    EXPECT_THAT(xad::value(ret2.imag()), DoubleNear(-1.2, 1e-9));
 }
+
+
 
 // -------------- operator- ---------------
 
 TYPED_TEST(ComplexTest, SubstractComplex)
 {
     auto z1 = std::complex<TypeParam>(1.2, -1.2);
+    auto z2 = std::complex<TypeParam>(1.2, 42.0);
+    auto ret = z1 - z2;
+    EXPECT_THAT(xad::value(ret.real()), DoubleNear(0.0, 1e-9));
+    EXPECT_THAT(xad::value(ret.imag()), DoubleNear(-43.2, 1e-9));
+}
+
+TYPED_TEST(ComplexTest, SubstractComplexDouble)
+{
+    auto z1 = std::complex<TypeParam>(1.2, -1.2);
+    auto z2 = std::complex<double>(1.2, 42.0);
+    auto ret = z1 - z2;
+    EXPECT_THAT(xad::value(ret.real()), DoubleNear(0.0, 1e-9));
+    EXPECT_THAT(xad::value(ret.imag()), DoubleNear(-43.2, 1e-9));
+}
+
+TYPED_TEST(ComplexTest, SubstractDoubleComplex)
+{
+    auto z1 = std::complex<double>(1.2, -1.2);
     auto z2 = std::complex<TypeParam>(1.2, 42.0);
     auto ret = z1 - z2;
     EXPECT_THAT(xad::value(ret.real()), DoubleNear(0.0, 1e-9));
@@ -896,9 +964,33 @@ TYPED_TEST(ComplexTest, SubstractScalar)
     EXPECT_THAT(xad::value(ret2.imag()), DoubleNear(1.2, 1e-9));
 }
 
+TYPED_TEST(ComplexTest, SubstractScalarDoubleCplx)
+{
+    auto z = std::complex<double>(1.2, -1.2);
+    TypeParam s = 1.2;
+    auto ret1 = z - s;
+    auto ret2 = s - z;
+    EXPECT_THAT(xad::value(ret1.real()), DoubleNear(0.0, 1e-9));
+    EXPECT_THAT(xad::value(ret1.imag()), DoubleNear(-1.2, 1e-9));
+    EXPECT_THAT(xad::value(ret2.real()), DoubleNear(0.0, 1e-9));
+    EXPECT_THAT(xad::value(ret2.imag()), DoubleNear(1.2, 1e-9));
+}
+
 TYPED_TEST(ComplexTest, SubstractScalarExpression)
 {
     auto z = std::complex<TypeParam>(1.2, -1.2);
+    TypeParam s = 1.2;
+    auto ret2 = (s * 1.0) - z;
+    auto ret = z - (s * 1.0);
+    EXPECT_THAT(xad::value(ret.real()), DoubleNear(0.0, 1e-9));
+    EXPECT_THAT(xad::value(ret.imag()), DoubleNear(-1.2, 1e-9));
+    EXPECT_THAT(xad::value(ret2.real()), DoubleNear(0.0, 1e-9));
+    EXPECT_THAT(xad::value(ret2.imag()), DoubleNear(1.2, 1e-9));
+}
+
+TYPED_TEST(ComplexTest, SubstractScalarExpressionDoubleCplx)
+{
+    auto z = std::complex<double>(1.2, -1.2);
     TypeParam s = 1.2;
     auto ret2 = (s * 1.0) - z;
     auto ret = z - (s * 1.0);
@@ -931,6 +1023,24 @@ TYPED_TEST(ComplexTest, MultiplyComplex)
     EXPECT_THAT(xad::value(ret.imag()), DoubleNear(48.96, 1e-9));
 }
 
+TYPED_TEST(ComplexTest, MultiplyComplexDouble)
+{
+    auto z1 = std::complex<TypeParam>(1.2, -1.2);
+    auto z2 = std::complex<double>(1.2, 42.0);
+    auto ret = z1 * z2;
+    EXPECT_THAT(xad::value(ret.real()), DoubleNear(51.84, 1e-9));
+    EXPECT_THAT(xad::value(ret.imag()), DoubleNear(48.96, 1e-9));
+}
+
+TYPED_TEST(ComplexTest, MultiplyDoubleComplex)
+{
+    auto z1 = std::complex<double>(1.2, -1.2);
+    auto z2 = std::complex<TypeParam>(1.2, 42.0);
+    auto ret = z1 * z2;
+    EXPECT_THAT(xad::value(ret.real()), DoubleNear(51.84, 1e-9));
+    EXPECT_THAT(xad::value(ret.imag()), DoubleNear(48.96, 1e-9));
+}
+
 TYPED_TEST(ComplexTest, MultiplyScalar)
 {
     auto z = std::complex<TypeParam>(1.2, -1.2);
@@ -943,9 +1053,33 @@ TYPED_TEST(ComplexTest, MultiplyScalar)
     EXPECT_THAT(xad::value(ret2.imag()), DoubleNear(-1.44, 1e-9));
 }
 
+TYPED_TEST(ComplexTest, MultiplyScalarDoubleCplx)
+{
+    auto z = std::complex<double>(1.2, -1.2);
+    TypeParam s = 1.2;
+    auto ret1 = z * s;
+    auto ret2 = s * z;
+    EXPECT_THAT(xad::value(ret1.real()), DoubleNear(1.44, 1e-9));
+    EXPECT_THAT(xad::value(ret1.imag()), DoubleNear(-1.44, 1e-9));
+    EXPECT_THAT(xad::value(ret2.real()), DoubleNear(1.44, 1e-9));
+    EXPECT_THAT(xad::value(ret2.imag()), DoubleNear(-1.44, 1e-9));
+}
+
 TYPED_TEST(ComplexTest, MultiplyScalarExpression)
 {
     auto z = std::complex<TypeParam>(1.2, -1.2);
+    TypeParam s = 1.2;
+    auto ret = z * (s * 1.0);
+    auto ret2 = (s * 1.0) * z;
+    EXPECT_THAT(xad::value(ret.real()), DoubleNear(1.44, 1e-9));
+    EXPECT_THAT(xad::value(ret.imag()), DoubleNear(-1.44, 1e-9));
+    EXPECT_THAT(xad::value(ret2.real()), DoubleNear(1.44, 1e-9));
+    EXPECT_THAT(xad::value(ret2.imag()), DoubleNear(-1.44, 1e-9));
+}
+
+TYPED_TEST(ComplexTest, MultiplyScalarExpressionDoubleCplx)
+{
+    auto z = std::complex<double>(1.2, -1.2);
     TypeParam s = 1.2;
     auto ret = z * (s * 1.0);
     auto ret2 = (s * 1.0) * z;
@@ -978,6 +1112,24 @@ TYPED_TEST(ComplexTest, DivideComplex)
     EXPECT_THAT(xad::value(ret.imag()), DoubleNear(-0.029363784665579117, 1e-9));
 }
 
+TYPED_TEST(ComplexTest, DivideComplexDouble)
+{
+    auto z1 = std::complex<TypeParam>(1.2, -1.2);
+    auto z2 = std::complex<double>(1.2, 42.0);
+    auto ret = z1 / z2;
+    EXPECT_THAT(xad::value(ret.real()), DoubleNear(-0.027732463295269166, 1e-9));
+    EXPECT_THAT(xad::value(ret.imag()), DoubleNear(-0.029363784665579117, 1e-9));
+}
+
+TYPED_TEST(ComplexTest, DivideDoubleComplex)
+{
+    auto z1 = std::complex<double>(1.2, -1.2);
+    auto z2 = std::complex<TypeParam>(1.2, 42.0);
+    auto ret = z1 / z2;
+    EXPECT_THAT(xad::value(ret.real()), DoubleNear(-0.027732463295269166, 1e-9));
+    EXPECT_THAT(xad::value(ret.imag()), DoubleNear(-0.029363784665579117, 1e-9));
+}
+
 TYPED_TEST(ComplexTest, DivideScalar)
 {
     auto z = std::complex<TypeParam>(1.2, -1.2);
@@ -990,9 +1142,33 @@ TYPED_TEST(ComplexTest, DivideScalar)
     EXPECT_THAT(xad::value(ret2.imag()), DoubleNear(0.5, 1e-9));
 }
 
+TYPED_TEST(ComplexTest, DivideScalarDoubleCplx)
+{
+    auto z = std::complex<double>(1.2, -1.2);
+    TypeParam s = 1.2;
+    auto ret1 = z / s;
+    auto ret2 = s / z;
+    EXPECT_THAT(xad::value(ret1.real()), DoubleNear(1.0, 1e-9));
+    EXPECT_THAT(xad::value(ret1.imag()), DoubleNear(-1.0, 1e-9));
+    EXPECT_THAT(xad::value(ret2.real()), DoubleNear(0.5, 1e-9));
+    EXPECT_THAT(xad::value(ret2.imag()), DoubleNear(0.5, 1e-9));
+}
+
 TYPED_TEST(ComplexTest, DivideScalarExpression)
 {
     auto z = std::complex<TypeParam>(1.2, -1.2);
+    TypeParam s = 1.2;
+    auto ret = z / (s * 1.0);
+    auto ret2 = (s * 1.0) / z;
+    EXPECT_THAT(xad::value(ret.real()), DoubleNear(1.0, 1e-9));
+    EXPECT_THAT(xad::value(ret.imag()), DoubleNear(-1.0, 1e-9));
+    EXPECT_THAT(xad::value(ret2.real()), DoubleNear(0.5, 1e-9));
+    EXPECT_THAT(xad::value(ret2.imag()), DoubleNear(0.5, 1e-9));
+}
+
+TYPED_TEST(ComplexTest, DivideScalarExpressionDoubleCplx)
+{
+    auto z = std::complex<double>(1.2, -1.2);
     TypeParam s = 1.2;
     auto ret = z / (s * 1.0);
     auto ret2 = (s * 1.0) / z;


### PR DESCRIPTION
# Description

This adds to possible to do basic arithmetic operations between `std::complex<xad::XReal<T>>` and `std::complex<T>`. 

## Type of change

-   Bug fix (non-breaking change which fixes an issue)