### PR TITLE
Adds new sample pricing a portfolio of LIBOR swaptions with derivatives

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -47,7 +47,13 @@ endif()
 
 # add a sample - link to XAD and add common to include path
 function(xad_add_sample name)
-    add_executable(${name} ${ARGN})
+    cmake_parse_arguments(ARGS "" "" "SOURCES;TEST_ARGS" ${ARGN})
+
+    if(NOT ARGS_SOURCES)
+        message(FATAL_ERROR "The SOURCES argument must be given for samples")
+    endif()
+
+    add_executable(${name} ${ARGS_SOURCES})
     target_link_libraries(${name} PRIVATE XAD::xad)
     target_include_directories(${name} PRIVATE ../common)
     get_target_property(msvcrt XAD::xad MSVC_RUNTIME_LIBRARY)
@@ -55,7 +61,7 @@ function(xad_add_sample name)
         set_target_properties(${name} PROPERTIES MSVC_RUNTIME_LIBRARY "${msvcrt}")
     endif()
     if(NOT XAD_SAMPLES_MAIN)
-        add_test(NAME sample_${name} COMMAND ${name})
+        add_test(NAME sample_${name} COMMAND ${name} ${ARGS_TEST_ARGS})
         set_target_properties(${name} PROPERTIES FOLDER "samples")
         if(XAD_ENABLE_ADDRESS_SANITIZER)
             target_compile_options(${name} PRIVATE ${xad_cxx_asan_flags})
@@ -72,5 +78,6 @@ add_subdirectory(SwapPricer)
 add_subdirectory(fwd_adj_2nd)
 add_subdirectory(Hessian)
 add_subdirectory(Jacobian)
+add_subdirectory(LiborSwaptionPricer)
 
 

--- a/samples/Jacobian/CMakeLists.txt
+++ b/samples/Jacobian/CMakeLists.txt
@@ -22,4 +22,4 @@
 #   
 ##############################################################################
 
-xad_add_sample(Jacobian main.cpp)
+xad_add_sample(Jacobian SOURCES main.cpp)

--- a/samples/LiborSwaptionPricer/CMakeLists.txt
+++ b/samples/LiborSwaptionPricer/CMakeLists.txt
@@ -1,6 +1,7 @@
 ##############################################################################
 #   
-#  Hessian sample CMake file
+#  Cmake file for 1st order adjoint mode for a Monte-Carlo Libor Swaption
+#  portfolio pricer.
 #
 #  This file is part of XAD, a comprehensive C++ library for
 #  automatic differentiation.
@@ -22,4 +23,14 @@
 #   
 ##############################################################################
 
-xad_add_sample(Hessian SOURCES main.cpp)
+xad_add_sample(LiborSwaptionPricer 
+  SOURCES 
+    LiborData.hpp  
+    LiborFunctions.hpp 
+    LiborPricers.hpp
+    LiborPricers.cpp 
+    main.cpp
+  TEST_ARGS
+    100 
+    test
+)

--- a/samples/LiborSwaptionPricer/LiborData.hpp
+++ b/samples/LiborSwaptionPricer/LiborData.hpp
@@ -1,0 +1,56 @@
+/*******************************************************************************
+
+   Data structures used to price a portfolio of LIBOR swaptions.
+
+   This file is part of XAD, a comprehensive C++ library for
+   automatic differentiation.
+
+   The code is an adapted version of Prof. Mike Giles, available here:
+   https://people.maths.ox.ac.uk/~gilesm/codes/libor_AD/testlinadj.cpp
+
+   Copyright (C) 2010-2024 Xcelerit Computing Ltd.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published
+   by the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+******************************************************************************/
+
+#pragma once
+
+#include <vector>
+
+
+/// Represents portfolio of swaptions, with maturities and corresponding
+/// swap rates
+struct SwaptionPortfolio
+{
+    std::vector<double> swaprates;
+    std::vector<int> maturities;
+};
+
+/// Market parameters required for pricing
+struct MarketParameters
+{
+    double delta = 0.;
+    std::vector<double> lambda;
+    std::vector<double> L0;
+};
+
+/// Holds portfolio price and derivatives
+struct Results
+{
+    double price = 0.;
+    double d_delta = 0.;
+    std::vector<double> d_L0;
+    std::vector<double> d_lambda;
+};

--- a/samples/LiborSwaptionPricer/LiborFunctions.hpp
+++ b/samples/LiborSwaptionPricer/LiborFunctions.hpp
@@ -1,0 +1,101 @@
+/*******************************************************************************
+
+   Functions used to price a portfolio of LIBOR swaptions.
+
+   This file is part of XAD, a comprehensive C++ library for
+   automatic differentiation.
+
+   The code is an adapted version of Prof. Mike Giles, available here:
+   https://people.maths.ox.ac.uk/~gilesm/codes/libor_AD/testlinadj.cpp
+
+   Copyright (C) 2010-2024 Xcelerit Computing Ltd.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published
+   by the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+******************************************************************************/
+
+#pragma once
+
+#include <vector>
+
+//////////////////// Pricing functions ////////////////
+// Defined as templates, so that they can be used   ///
+// with active and passive types
+///////////////////////////////////////////////////////
+
+/// Path generation - calculates LIBOR rates at the given times,
+/// Based on Gaussian randdom numbers
+template <class ADT>
+void path_gen(const ADT& delta, std::vector<ADT>& L, const std::vector<ADT>& lambda,
+              const std::vector<double>& z)
+{
+    using std::exp;
+    using std::sqrt;
+
+    for (size_t n = 0; n < z.size(); n++)
+    {
+        ADT sqez = sqrt(delta) * z[n];
+
+        ADT v = 0.0;
+        for (size_t i = n + 1; i < L.size(); i++)
+        {
+            ADT lam = lambda[i - n - 1];
+            ADT con1 = delta * lam;
+            v += (con1 * L[i]) / (1.0 + delta * L[i]);
+            L[i] *= exp(con1 * v + lam * (sqez - 0.5 * con1));
+        }
+    }
+}
+
+/// Value the swap portfolio for the given LIBOR rates
+template <class ADT>
+ADT value_portfolio(const ADT delta, const std::vector<int>& maturities,
+                    const std::vector<double>& swaprates, const std::vector<ADT>& L,
+                    std::vector<ADT>& Btmp, std::vector<ADT>& Stmp)
+{
+    const size_t NN = L.size();
+    const size_t N = NN / 2;
+    const size_t Nopt = swaprates.size();
+
+    // temporaries, passed as parameters to avoid re-allocating
+    Btmp.resize(NN);
+    Stmp.resize(NN);
+
+    ADT b = 1.0;
+    ADT s = 0.0;
+
+    for (size_t n = N; n < NN; ++n)
+    {
+        b = b / (1.0 + delta * L[n]);
+        s = s + delta * b;
+        Btmp[n] = b;
+        Stmp[n] = s;
+    }
+
+    ADT v = 0.0;
+
+    for (size_t i = 0; i < Nopt; i++)
+    {
+        int m = maturities[i] + N - 1;
+        ADT swapval = Btmp[m] + swaprates[i] * Stmp[m] - 1.0;
+        if (swapval < 0.)
+            v += -100.0 * swapval;
+    }
+
+    // apply discount
+
+    for (size_t n = 0; n < N; n++) v = v / (1.0 + delta * L[n]);
+
+    return v;
+}

--- a/samples/LiborSwaptionPricer/LiborPricers.cpp
+++ b/samples/LiborSwaptionPricer/LiborPricers.cpp
@@ -1,0 +1,213 @@
+/*******************************************************************************
+
+   Pricing functions for a portfolio of LIBOR swaptions.
+
+   This file is part of XAD, a comprehensive C++ library for
+   automatic differentiation.
+
+   The code is an adapted version of Prof. Mike Giles, available here:
+   https://people.maths.ox.ac.uk/~gilesm/codes/libor_AD/testlinadj.cpp
+
+   Copyright (C) 2010-2024 Xcelerit Computing Ltd.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published
+   by the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+******************************************************************************/
+
+#include <XAD/XAD.hpp>
+#include "LiborData.hpp"
+#include "LiborFunctions.hpp"
+#include <random>
+
+Results pricePortfolio(const SwaptionPortfolio& portfolio, const MarketParameters& market,
+                       int numPaths, unsigned long long seed)
+{
+    std::mt19937 gen(seed);
+    std::normal_distribution<double> dist(0., 1.);
+    std::vector<double> samples(market.lambda.size() / 2);
+    std::vector<double> L, tmp1, tmp2;
+
+    Results res;
+    res.price = 0.;
+    for (int path = 0; path < numPaths; ++path)
+    {
+        // generate random samples
+        std::generate(begin(samples), end(samples), [&]() { return dist(gen); });
+        // generate the path, calculating LIBOR rates
+        L.assign(begin(market.L0), end(market.L0));
+        path_gen(market.delta, L, market.lambda, samples);
+        // price portfolio on that path
+        double v =
+            value_portfolio(market.delta, portfolio.maturities, portfolio.swaprates, L, tmp1, tmp2);
+        res.price += v;
+    }
+    res.price /= numPaths;
+
+    return res;
+}
+
+// tape and active data type for 1st order adjoint computation
+typedef xad::adj<double> mode;
+typedef mode::tape_type tape_type;
+typedef mode::active_type AD;
+
+tape_type tape;
+
+Results pricePortfolioAD(const SwaptionPortfolio& portfolio, const MarketParameters& market,
+                         int numPaths, unsigned long long seed = 12354)
+{
+    std::mt19937 gen(seed);
+    std::normal_distribution<double> dist(0., 1.);
+    std::vector<double> samples(market.lambda.size() / 2);
+
+    // AD types setup / copy input data
+    std::vector<AD> L, tmp1, tmp2;
+    std::vector<AD> lambda, L0;
+
+    Results res;
+    res.price = 0.;
+    res.d_lambda.resize(market.lambda.size());
+    res.d_delta = 0.0;
+    res.d_L0.resize(market.L0.size());
+    for (int path = 0; path < numPaths; ++path)
+    {
+        // pathwise approach - make sure variables are erased
+        tmp1.clear();
+        tmp2.clear();
+        L.clear();
+        lambda.clear();
+        L0.clear();
+        tape.clearAll();
+
+        // assign and register inputs
+        AD delta = market.delta;
+        lambda.assign(begin(market.lambda), end(market.lambda));
+        L0.assign(begin(market.L0), end(market.L0));
+        tape.registerInput(delta);
+        tape.registerInputs(lambda);
+        tape.registerInputs(L0);
+        tape.newRecording();
+
+        // generate random samples
+        std::generate(begin(samples), end(samples), [&]() { return dist(gen); });
+        // generate the path, calculating LIBOR rates
+        L.assign(begin(L0), end(L0));
+        path_gen(delta, L, lambda, samples);
+        // price portfolio on that path
+        AD v = value_portfolio(delta, portfolio.maturities, portfolio.swaprates, L, tmp1, tmp2);
+        tape.registerOutput(v);
+        derivative(v) = 1.0;
+        tape.computeAdjoints();
+
+        // update value and derivatives
+        res.price += value(v);
+        res.d_delta += derivative(delta);
+        for (size_t i = 0; i < market.lambda.size(); ++i)
+        {
+            res.d_lambda[i] += derivative(lambda[i]);
+            res.d_L0[i] += derivative(L0[i]);
+        }
+    }
+
+    // averaging
+    res.price /= numPaths;
+    res.d_delta /= numPaths;
+    for (size_t i = 0; i < market.lambda.size(); ++i)
+    {
+        res.d_lambda[i] /= numPaths;
+        res.d_L0[i] /= numPaths;
+    }
+
+    return res;
+}
+
+Results pricePortfolioFD(const SwaptionPortfolio& portfolio, const MarketParameters& market,
+                         int numPaths, unsigned long long seed = 12354)
+{
+    std::mt19937 gen(seed);
+    std::normal_distribution<double> dist(0., 1.);
+    std::vector<double> samples(market.lambda.size() / 2);
+    std::vector<double> L, tmp1, tmp2;
+
+    Results res;
+    res.price = 0.;
+    res.d_lambda.resize(market.lambda.size());
+    res.d_delta = 0.0;
+    res.d_L0.resize(market.L0.size());
+    for (int path = 0; path < numPaths; ++path)
+    {
+        // generate random samples
+        std::generate(begin(samples), end(samples), [&]() { return dist(gen); });
+
+        // first get the value of this path
+
+        // generate the path, calculating LIBOR rates
+        L.assign(begin(market.L0), end(market.L0));
+        path_gen(market.delta, L, market.lambda, samples);
+        // price portfolio on that path
+        double v =
+            value_portfolio(market.delta, portfolio.maturities, portfolio.swaprates, L, tmp1, tmp2);
+        res.price += v;
+
+        // now bump inputs one by one to get all derivatives with finite differences
+        double eps = 1e-5;
+        {
+            auto d = market.delta + eps;
+            L.assign(begin(market.L0), end(market.L0));
+            path_gen(d, L, market.lambda, samples);
+            tmp1.clear();
+            tmp2.clear();
+            // price portfolio on that path
+            double v1 =
+                value_portfolio(d, portfolio.maturities, portfolio.swaprates, L, tmp1, tmp2);
+            res.d_delta += (v1 - v) / eps;
+        }
+
+        for (size_t i = 0; i < market.L0.size(); ++i)
+        {
+            L.assign(begin(market.L0), end(market.L0));
+            tmp1.clear();
+            tmp2.clear();
+            L[i] += eps;
+            path_gen(market.delta, L, market.lambda, samples);
+            // price portfolio on that path
+            double v1 = value_portfolio(market.delta, portfolio.maturities, portfolio.swaprates, L,
+                                        tmp1, tmp2);
+            res.d_L0[i] += (v1 - v) / eps;
+        }
+        auto lambda = market.lambda;
+        for (size_t i = 0; i < market.lambda.size(); ++i)
+        {
+            L.assign(begin(market.L0), end(market.L0));
+            tmp1.clear();
+            tmp2.clear();
+            lambda[i] += eps;
+            path_gen(market.delta, L, lambda, samples);
+            // price portfolio on that path
+            double v1 = value_portfolio(market.delta, portfolio.maturities, portfolio.swaprates, L,
+                                        tmp1, tmp2);
+            lambda[i] -= eps;
+            res.d_lambda[i] += (v1 - v) / eps;
+        }
+    }
+    res.price /= numPaths;
+    res.d_delta /= numPaths;
+    for (size_t i = 0; i < market.lambda.size(); ++i)
+    {
+        res.d_lambda[i] /= numPaths;
+        res.d_L0[i] /= numPaths;
+    }
+
+    return res;
+}

--- a/samples/LiborSwaptionPricer/LiborPricers.hpp
+++ b/samples/LiborSwaptionPricer/LiborPricers.hpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+
+   Pricing functions for a portfolio of LIBOR swaptions.
+
+   This file is part of XAD, a comprehensive C++ library for
+   automatic differentiation.
+
+   The code is an adapted version of Prof. Mike Giles, available here:
+   https://people.maths.ox.ac.uk/~gilesm/codes/libor_AD/testlinadj.cpp
+
+   Copyright (C) 2010-2024 Xcelerit Computing Ltd.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published
+   by the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+******************************************************************************/
+
+#pragma once
+#include "LiborData.hpp"
+
+/// Pure pricing without sensitivities
+Results pricePortfolio(const SwaptionPortfolio& portfolio, const MarketParameters& market,
+                       int numPaths, unsigned long long seed = 12354);
+
+/// Price with first-order sensitivities, using AAD
+Results pricePortfolioAD(const SwaptionPortfolio& portfolio, const MarketParameters& market,
+                         int numPaths, unsigned long long seed = 12354);
+
+/// Price with first-order sensitivities, estimated using finite differences
+Results pricePortfolioFD(const SwaptionPortfolio& portfolio, const MarketParameters& market,
+                         int numPaths, unsigned long long seed = 12354);

--- a/samples/LiborSwaptionPricer/main.cpp
+++ b/samples/LiborSwaptionPricer/main.cpp
@@ -1,0 +1,155 @@
+/*******************************************************************************
+
+   1st order adjoint mode for a Monte-Carlo LIBOR Swaption
+   portfolio pricer.
+
+   This file is part of XAD, a comprehensive C++ library for
+   automatic differentiation.
+
+   The code is an adapted version of Prof. Mike Giles, available here:
+   https://people.maths.ox.ac.uk/~gilesm/codes/libor_AD/testlinadj.cpp
+
+   Copyright (C) 2010-2024 Xcelerit Computing Ltd.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published
+   by the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+******************************************************************************/
+
+#include "LiborData.hpp"
+#include "LiborPricers.hpp"
+
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+SwaptionPortfolio setupTestPortfolio()
+{
+    SwaptionPortfolio p;
+    // maturities of the swaptions in years
+    p.maturities = {4, 4, 4, 8, 8, 8, 20, 20, 20, 28, 28, 28, 40, 40, 40};
+    p.swaprates = {.045, .05,  .055, .045, .05,  .055, .045, .05,
+                   .055, .045, .05,  .055, .045, .05,  .055};
+    return p;
+}
+
+MarketParameters setupTestMarket()
+{
+    MarketParameters market;
+    market.delta = 0.05;
+    market.L0.assign(80, 0.05);
+    market.lambda.assign(80, 0.2);
+    return market;
+}
+
+bool checkError(double ad_value, double fd_value, const std::string& what)
+{
+    if (std::abs(ad_value - fd_value) / (fd_value + 1e-6) > 1e-4)
+    {
+        std::cerr << std::fixed << std::setprecision(10);
+        std::cerr << what << ": AD " << ad_value << " does not match FD " << fd_value << "\n";
+        return true;
+    }
+    return false;
+}
+
+/// Runs pricing given number of paths and optionally tests against finite differences
+/// for correctness.
+///
+/// Usage:
+///   LiborSwaptionPricer [numPaths] [test]
+///
+/// By default, it uses 10,000 paths and does not run tests against finite differences.
+///
+/// For example, for running 100,000 paths and compare to finite differences:
+///
+/// LiborSwaptionPricer 100000 test
+///
+int main(int argc, char** argv)
+{
+    const int NUM_PATHS = argc < 2 ? 10000 : std::atol(argv[1]);
+    const bool doTests = argc < 3 ? false : argv[2] == std::string("test");
+    constexpr unsigned long long SEED = 91672912;
+
+    SwaptionPortfolio p = setupTestPortfolio();
+    MarketParameters market = setupTestMarket();
+
+    std::cout << std::fixed << std::setprecision(8);
+
+    std::cout << "-------- Pure pricing ---------------------\n";
+    auto start{std::chrono::steady_clock::now()};
+    auto resPlain = pricePortfolio(p, market, NUM_PATHS, SEED);
+    auto end{std::chrono::steady_clock::now()};
+    std::cout << "Portfolio price = " << resPlain.price << "\n";
+    std::chrono::duration<double> elapsed_plain{end - start};
+
+    std::cout << "-------- AD pricing -----------------------\n";
+    start = std::chrono::steady_clock::now();
+    auto resAD = pricePortfolioAD(p, market, NUM_PATHS, SEED);
+    end = std::chrono::steady_clock::now();
+    std::cout << "Portfolio price         = " << resAD.price << "\n";
+    std::cout << "Derivative w.r.t. delta = " << resAD.d_delta << "\n";
+    for (size_t i = 0; i < market.lambda.size(); ++i)
+    {
+        std::cout << "Derivative w.r.t. lambda[" << i << "] = " << resAD.d_lambda[i] << "\n";
+    }
+    for (size_t i = 0; i < market.L0.size(); ++i)
+    {
+        std::cout << "Derivative w.r.t. L0[" << i << "] = " << resAD.d_L0[i] << "\n";
+    }
+    std::chrono::duration<double> elapsed_ad{end - start};
+
+    bool hasError = checkError(resAD.price, resPlain.price, "price");
+    if (hasError)
+    {
+        return 1;
+    }
+
+    std::cout << std::fixed << std::setprecision(3);
+
+    std::cout << "\n";
+    std::cout << "----- Plain: " << std::setw(8) << elapsed_plain.count() << " seconds\n";
+    std::cout << "----- AAD  : " << std::setw(8) << elapsed_ad.count() << " seconds\n";
+
+    if (doTests)
+    {
+        start = std::chrono::steady_clock::now();
+        auto resFD = pricePortfolioFD(p, market, NUM_PATHS, SEED);
+        end = std::chrono::steady_clock::now();
+        std::chrono::duration<double> elapsed_fd{end - start};
+        std::cout << "----- FD   : " << std::setw(8) << elapsed_fd.count() << " seconds\n";
+
+        for (size_t i = 0; i < market.lambda.size(); ++i)
+        {
+            hasError = checkError(resAD.d_lambda[i], resFD.d_lambda[i],
+                                  "lambda[" + std::to_string(i) + "]") ||
+                       hasError;
+        }
+        for (size_t i = 0; i < market.L0.size(); ++i)
+        {
+            hasError = checkError(resAD.d_L0[i], resFD.d_L0[i], "L0[" + std::to_string(i) + "]") ||
+                       hasError;
+        }
+
+        if (hasError)
+        {
+            std::cerr << "\nThere were errors.\n";
+            return 1;
+        }
+        std::cout << "\nAll tests passed.\n";
+    }
+
+    return 0;
+}

--- a/samples/SwapPricer/CMakeLists.txt
+++ b/samples/SwapPricer/CMakeLists.txt
@@ -22,4 +22,4 @@
 #   
 ##############################################################################
 
-xad_add_sample(SwapPricer main.cpp SwapPricer.hpp )
+xad_add_sample(SwapPricer SOURCES main.cpp SwapPricer.hpp )

--- a/samples/adj_1st/CMakeLists.txt
+++ b/samples/adj_1st/CMakeLists.txt
@@ -22,4 +22,4 @@
 #   
 ##############################################################################
 
-xad_add_sample(adj_1st main.cpp ../common/functions.hpp)
+xad_add_sample(adj_1st SOURCES main.cpp ../common/functions.hpp)

--- a/samples/checkpointing/CMakeLists.txt
+++ b/samples/checkpointing/CMakeLists.txt
@@ -23,6 +23,7 @@
 ##############################################################################
 
 xad_add_sample(checkpointing
+  SOURCES 
     main.cpp
     sin_checkpoint.hpp
     ../common/functions.hpp

--- a/samples/external_function/CMakeLists.txt
+++ b/samples/external_function/CMakeLists.txt
@@ -23,6 +23,7 @@
 ##############################################################################
 
 xad_add_sample(external_function 
+  SOURCES 
     main.cpp 
     external_sum_elements.hpp
     ../common/functions.hpp)

--- a/samples/fwd_1st/CMakeLists.txt
+++ b/samples/fwd_1st/CMakeLists.txt
@@ -22,4 +22,4 @@
 #   
 ##############################################################################
 
-xad_add_sample(fwd_1st main.cpp ../common/functions.hpp)
+xad_add_sample(fwd_1st SOURCES main.cpp ../common/functions.hpp)

--- a/samples/fwd_adj_2nd/CMakeLists.txt
+++ b/samples/fwd_adj_2nd/CMakeLists.txt
@@ -22,4 +22,4 @@
 #   
 ##############################################################################
 
-xad_add_sample(fwd_adj_2nd main.cpp ../common/functions.hpp)
+xad_add_sample(fwd_adj_2nd SOURCES main.cpp ../common/functions.hpp)


### PR DESCRIPTION
# Description

This adds a more elaborate example application which prices a portfolio of LIBOR Swaptions using a Monte-Carlo approach.
It calculates derivatives with adjoint mode using the path-wise approach, 
i.e. it calculates them independently for each path and averages them in the end.

## Type of change

-   New feature (non-breaking change which adds functionality)