### PR TITLE
Hackathon: The Foxers

### DIFF
--- a/src/Tape.cpp
+++ b/src/Tape.cpp
@@ -588,7 +588,8 @@ void Tape<T>::computeAdjointsToImpl(position_type pos, position_type start)
                     auto multiplier = multiplier_[opi];
                     auto slot = slot_[opi];
                     auto& der = derivatives_[slot];
-                    der = detail::fused_multiply_add(multiplier, a, der);
+                    // der = detail::fused_multiply_add(multiplier, a, der);
+                    der += multiplier * a;
                 }
             }
         }
@@ -603,8 +604,11 @@ void Tape<T>::computeAdjointsToImpl(position_type pos, position_type start)
             {
                 for (auto opi = prevendpoint, ope = st.first; opi != ope; ++opi)
                 {
-                    derivatives_[slot_[opi]] =
-                        detail::fused_multiply_add(multiplier_[opi], a, derivatives_[slot_[opi]]);
+                    auto multiplier = multiplier_[opi];
+                    auto slot = slot_[opi];
+                    auto& der = derivatives_[slot];
+                    // der = detail::fused_multiply_add(multiplier, a, der);
+                    der += multiplier * a;
                 }
             }
         }

--- a/src/XAD/ChunkContainer.hpp
+++ b/src/XAD/ChunkContainer.hpp
@@ -227,9 +227,10 @@ class ChunkContainer
         }
     }
 
-    void push_back(const_reference v)
+    XAD_FORCE_INLINE void push_back(const_reference v)
     {
-        check_space();
+        if (__builtin_expect(idx_ == chunk_size, false))
+            check_space();
 
         ::new (reinterpret_cast<value_type*>(chunkList_[chunk_]) + idx_) value_type(v);
         ++idx_;
@@ -238,7 +239,8 @@ class ChunkContainer
     template <class... Args>
     void emplace_back(Args&&... args)
     {
-        check_space();
+        if (__builtin_expect(idx_ == chunk_size, false))
+            check_space();
         ::new (chunkList_[chunk_] + idx_ * sizeof(value_type))
             value_type(std::forward<Args>(args)...);
         ++idx_;
@@ -300,7 +302,9 @@ class ChunkContainer
             auto endn = chunk_size - idx_;
             for (size_type i = 0; i < endn; ++i) ::new (dst++) value_type(*first++);
             idx_ = chunk_size;
-            check_space();  // appends a chunk, moves idx_ / chunk_
+            if (__builtin_expect(idx_ == chunk_size, false))
+                check_space(); // appends a chunk, moves idx_ / chunk_
+            // check_space();  // appends a chunk, moves idx_ / chunk_
             endn = static_cast<size_type>(std::distance(first, last));
             dst = reinterpret_cast<value_type*>(chunkList_[chunk_]);
             for (size_type i = 0; i < endn; ++i) ::new (dst++) value_type(*first++);
@@ -432,8 +436,8 @@ class ChunkContainer
   private:
     void check_space()
     {
-        if (idx_ == chunk_size)
-        {
+        //if (idx_ == chunk_size)
+        //{
             if (chunk_ == chunkList_.size() - 1)
             {
                 char* chunk = reinterpret_cast<char*>(
@@ -444,7 +448,7 @@ class ChunkContainer
             }
             ++chunk_;
             idx_ = 0;
-        }
+        //}
     }
 
     void check_space(size_type i) { reserve(chunk_ * chunk_size + idx_ + i); }


### PR DESCRIPTION
# Description

Calling check_space only when the condition is met and forcing inlining of push_back in the ChunkContainer eliminates the overhead of the function call stack. Similarly, replacing the fused_multiply_add function directly in the caller function in Tap.cpp removes its overhead.


