### PR TITLE
Hackathon Team Lambda Optimizations

### DIFF
--- a/src/Tape.cpp
+++ b/src/Tape.cpp
@@ -50,7 +50,7 @@ Tape<T>::Tape(bool activateNow)
     currentRec_ = &nestedRecordings_.top();
     if (activateNow)
         activate();
-    statement_.push_back_reserved(
+    statement_.push_back(
         std::make_pair(size_type(mult_slot_.size()), slot_type(INVALID_SLOT)));
 }
 

--- a/src/Tape.cpp
+++ b/src/Tape.cpp
@@ -50,7 +50,7 @@ Tape<T>::Tape(bool activateNow)
     currentRec_ = &nestedRecordings_.top();
     if (activateNow)
         activate();
-    statement_.push_back(std::make_pair(size_type(slot_.size()), slot_type(INVALID_SLOT)));
+    statement_.push_back_reserved(std::make_pair(size_type(slot_.size()), slot_type(INVALID_SLOT)));
 }
 
 template <class T>
@@ -529,6 +529,14 @@ void Tape<T>::computeAdjointsTo(position_type pos)
     LOG_DEBUG("after checkpoints, we go from " << start << " to " << pos);
     if (start > pos)
         computeAdjointsToImpl(pos, start);
+}
+
+template<typename T>
+XAD_FORCE_INLINE void Tape<T>::reserve_for_expr(Tape::size_type numVariables)
+{
+    slot_.reserve(numVariables);
+    multiplier_.reserve(numVariables);
+    statement_.reserve(numVariables);
 }
 
 namespace detail

--- a/src/Tape.cpp
+++ b/src/Tape.cpp
@@ -50,7 +50,8 @@ Tape<T>::Tape(bool activateNow)
     currentRec_ = &nestedRecordings_.top();
     if (activateNow)
         activate();
-    statement_.push_back_reserved(std::make_pair(size_type(mult_slot_.size()), slot_type(INVALID_SLOT)));
+    statement_.push_back_reserved(
+        std::make_pair(size_type(mult_slot_.size()), slot_type(INVALID_SLOT)));
 }
 
 template <class T>
@@ -526,7 +527,7 @@ void Tape<T>::computeAdjointsTo(position_type pos)
         computeAdjointsToImpl(pos, start);
 }
 
-template<typename T>
+template <typename T>
 XAD_FORCE_INLINE void Tape<T>::reserve_for_expr(typename Tape::size_type numVariables)
 {
     mult_slot_.reserve(numVariables);

--- a/src/Tape.cpp
+++ b/src/Tape.cpp
@@ -527,7 +527,7 @@ void Tape<T>::computeAdjointsTo(position_type pos)
 }
 
 template<typename T>
-XAD_FORCE_INLINE void Tape<T>::reserve_for_expr(Tape::size_type numVariables)
+XAD_FORCE_INLINE void Tape<T>::reserve_for_expr(typename Tape::size_type numVariables)
 {
     mult_slot_.reserve(numVariables);
     statement_.reserve(numVariables);

--- a/src/Tape.cpp
+++ b/src/Tape.cpp
@@ -530,7 +530,7 @@ template<typename T>
 XAD_FORCE_INLINE void Tape<T>::reserve_for_expr(typename Tape::size_type numVariables)
 {
     mult_slot_.reserve(numVariables);
-    statement_.reserve(numVariables);
+    statement_.reserve(1);
 }
 
 namespace detail

--- a/src/Tape.cpp
+++ b/src/Tape.cpp
@@ -588,16 +588,11 @@ void Tape<T>::computeAdjointsToImpl(position_type pos, position_type start)
         {
             auto st = *it;
             auto a = derivatives_[st.second];
-            derivatives_[st.second] = T();
             if (a != T())
             {
+                derivatives_[st.second] = T();
                 for (auto opi = it[-1].first, ope = st.first; opi != ope; ++opi)
-                {
-                    auto multiplier = multiplier_[opi];
-                    auto slot = slot_[opi];
-                    auto& der = derivatives_[slot];
-                    der = detail::fused_multiply_add(multiplier, a, der);
-                }
+                    derivatives_[slot_[opi]] += multiplier_[opi] * a;
             }
         }
         // last iteration separate
@@ -606,14 +601,11 @@ void Tape<T>::computeAdjointsToImpl(position_type pos, position_type start)
                 endidx == 0 ? chunk_it[-1][chunksz - 1].first : chunk_it[0][endidx - 1].first;
             auto st = chunk_it[0][endidx];
             auto a = derivatives_[st.second];
-            derivatives_[st.second] = T();
             if (a != T())
             {
+                derivatives_[st.second] = T();
                 for (auto opi = prevendpoint, ope = st.first; opi != ope; ++opi)
-                {
-                    derivatives_[slot_[opi]] =
-                        detail::fused_multiply_add(multiplier_[opi], a, derivatives_[slot_[opi]]);
-                }
+                    derivatives_[slot_[opi]] += multiplier_[opi] * a;
             }
         }
 

--- a/src/Tape.cpp
+++ b/src/Tape.cpp
@@ -50,13 +50,12 @@ Tape<T>::Tape(bool activateNow)
     currentRec_ = &nestedRecordings_.top();
     if (activateNow)
         activate();
-    statement_.push_back_reserved(std::make_pair(size_type(slot_.size()), slot_type(INVALID_SLOT)));
+    statement_.push_back_reserved(std::make_pair(size_type(mult_slot_.size()), slot_type(INVALID_SLOT)));
 }
 
 template <class T>
 Tape<T>::Tape(Tape&& o) noexcept
-    : multiplier_(std::move(o.multiplier_)),
-      slot_(std::move(o.slot_)),
+    : mult_slot_(std::move(o.mult_slot_)),
       statement_(std::move(o.statement_)),
       derivatives_(std::move(o.derivatives_)),
       checkpoints_(std::move(o.checkpoints_)),
@@ -76,8 +75,7 @@ Tape<T>::Tape(Tape&& o) noexcept
 template <class T>
 Tape<T>& Tape<T>::operator=(Tape&& o) noexcept
 {
-    multiplier_ = std::move(o.multiplier_);
-    slot_ = std::move(o.slot_);
+    mult_slot_ = std::move(o.mult_slot_);
     statement_ = std::move(o.statement_);
     derivatives_ = std::move(o.derivatives_);
     checkpoints_ = std::move(o.checkpoints_);
@@ -104,8 +102,7 @@ Tape<T>::~Tape()
 template <class T>
 void Tape<T>::clearAll()
 {
-    multiplier_.clear();
-    slot_.clear();
+    mult_slot_.clear();
     statement_.clear();
     derivatives_.clear();
     checkpoints_.clear();
@@ -113,7 +110,7 @@ void Tape<T>::clearAll()
     reusable_ranges_.clear();
 #endif
     while (!nestedRecordings_.empty()) nestedRecordings_.pop();
-    statement_.push_back(std::make_pair(size_type(slot_.size()), slot_type(INVALID_SLOT)));
+    statement_.push_back(std::make_pair(size_type(mult_slot_.size()), slot_type(INVALID_SLOT)));
     nestedRecordings_.push(SubRecording(this));
     currentRec_ = &nestedRecordings_.top();
 }
@@ -307,10 +304,9 @@ void Tape<T>::foldSubrecording()
     //     << ", cur max: " << cur->maxDerivative_ << "\n";
     if (derivatives_.size() > cur->maxDerivative_)
         derivatives_.resize(cur->maxDerivative_);
-    if (multiplier_.size() > prev.opStartPos_)
+    if (mult_slot_.size() > prev.opStartPos_)
     {
-        slot_.resize(prev.opStartPos_);
-        multiplier_.resize(prev.opStartPos_);
+        mult_slot_.resize(prev.opStartPos_);
     }
     if (statement_.size() > prev.statementStartPos_)
         statement_.resize(prev.statementStartPos_);
@@ -346,7 +342,7 @@ void Tape<T>::newNestedRecording()
     currentRec_->maxDerivative_ = currentRec_->prevMax_;
 
     newr.statementStartPos_ = slot_type(statement_.size());
-    newr.opStartPos_ = slot_type(multiplier_.size());
+    newr.opStartPos_ = slot_type(mult_slot_.size());
     newr.derivativesInitialized_ = false;
     newr.startDerivative_ = currentRec_->maxDerivative_;
     nestedRecordings_.push(newr);
@@ -368,20 +364,19 @@ void Tape<T>::endNestedRecording()
 template <class T>
 void Tape<T>::newRecording()
 {
-    multiplier_.clear();
-    slot_.clear();
+    mult_slot_.clear();
     statement_.clear();
     checkpoints_.clear();
     foldSubrecordings();
     currentRec_->maxDerivative_ = currentRec_->iDerivative_ + 1;
-    statement_.push_back(std::make_pair(size_type(slot_.size()), slot_type(INVALID_SLOT)));
+    statement_.push_back(std::make_pair(size_type(mult_slot_.size()), slot_type(INVALID_SLOT)));
     currentRec_->derivativesInitialized_ = false;
 }
 
 template <class T>
 typename Tape<T>::size_type Tape<T>::getNumOperations() const
 {
-    return size_type(slot_.size());
+    return size_type(mult_slot_.size());
 }
 
 template <class T>
@@ -471,7 +466,7 @@ void Tape<T>::printStatus() const
     }
     std::cout << "XAD Tape Info:\n"
               << "   Statements: " << statement_.size() - 1 << "\n"
-              << "   Operations: " << slot_.size() << "\n"
+              << "   Operations: " << mult_slot_.size() << "\n"
               << "   Total der : " << currentRec_->maxDerivative_ << "\n"
               << "   Der alloc : " << derivatives_.size() << "\n"
               << "   curr der  : " << currentRec_->numDerivatives_ << "\n"
@@ -534,8 +529,7 @@ void Tape<T>::computeAdjointsTo(position_type pos)
 template<typename T>
 XAD_FORCE_INLINE void Tape<T>::reserve_for_expr(Tape::size_type numVariables)
 {
-    slot_.reserve(numVariables);
-    multiplier_.reserve(numVariables);
+    mult_slot_.reserve(numVariables);
     statement_.reserve(numVariables);
 }
 
@@ -592,7 +586,10 @@ void Tape<T>::computeAdjointsToImpl(position_type pos, position_type start)
             {
                 derivatives_[st.second] = T();
                 for (auto opi = it[-1].first, ope = st.first; opi != ope; ++opi)
-                    derivatives_[slot_[opi]] += multiplier_[opi] * a;
+                {
+                    auto& mult_slot_opi = mult_slot_[opi];
+                    derivatives_[mult_slot_opi.second] += mult_slot_opi.first * a;
+                }
             }
         }
         // last iteration separate
@@ -605,7 +602,10 @@ void Tape<T>::computeAdjointsToImpl(position_type pos, position_type start)
             {
                 derivatives_[st.second] = T();
                 for (auto opi = prevendpoint, ope = st.first; opi != ope; ++opi)
-                    derivatives_[slot_[opi]] += multiplier_[opi] * a;
+                {
+                    auto& mult_slot_opi = mult_slot_[opi];
+                    derivatives_[mult_slot_opi.second] += mult_slot_opi.first * a;
+                }
             }
         }
 
@@ -616,8 +616,8 @@ void Tape<T>::computeAdjointsToImpl(position_type pos, position_type start)
 template <class T>
 std::size_t Tape<T>::getMemory() const
 {
-    return sizeof(T) * (multiplier_.size() + derivatives_.size()) +
-           sizeof(slot_type) * (slot_.size() +
+    return sizeof(T) * (mult_slot_.size() + derivatives_.size()) +
+           sizeof(slot_type) * (mult_slot_.size() +
                                 // statement_endpoint_.size() + statement_slot_.size()
                                 2 * statement_.size())
 #ifdef XAD_TAPE_REUSE_SLOTS
@@ -639,7 +639,7 @@ template <class T>
 void Tape<T>::insertCallback(CheckpointCallback<Tape<T> >* cb)
 {
     checkpoints_.push_back(std::make_pair(position_type(statement_.size()), cb));
-    statement_.push_back(std::make_pair(size_type(slot_.size()), slot_type(INVALID_SLOT)));
+    statement_.push_back(std::make_pair(size_type(mult_slot_.size()), slot_type(INVALID_SLOT)));
 }
 
 template <class T>
@@ -666,8 +666,7 @@ void Tape<T>::resetTo(position_type pos)
 
     std::pair<slot_type, slot_type> st = statement_[pos];
     statement_.resize(pos + 1);
-    multiplier_.resize(st.first);
-    slot_.resize(st.first);
+    mult_slot_.resize(st.first);
     if (!checkpoints_.empty())
     {
         auto newend = std::upper_bound(std::begin(checkpoints_), std::end(checkpoints_), pos,

--- a/src/XAD/ChunkContainer.hpp
+++ b/src/XAD/ChunkContainer.hpp
@@ -237,7 +237,7 @@ class ChunkContainer
 
     void push_back_reserved(const_reference v)
     {
-        assert(idx_ <= chunk_size);
+        assert(idx_ < chunk_size);
         ::new (reinterpret_cast<value_type*>(chunkList_[chunk_ + (idx_ / chunk_size)]) +
                (idx_ % chunk_size)) value_type(v);
         ++idx_;

--- a/src/XAD/ChunkContainer.hpp
+++ b/src/XAD/ChunkContainer.hpp
@@ -235,6 +235,13 @@ class ChunkContainer
         ++idx_;
     }
 
+    void push_back_reserved(const_reference v)
+    {
+        assert(idx_ <= chunk_size);
+        ::new (reinterpret_cast<value_type*>(chunkList_[chunk_]) + idx_) value_type(v);
+        ++idx_;
+    }
+
     template <class... Args>
     void emplace_back(Args&&... args)
     {

--- a/src/XAD/ChunkContainer.hpp
+++ b/src/XAD/ChunkContainer.hpp
@@ -238,7 +238,7 @@ class ChunkContainer
     void push_back_reserved(const_reference v)
     {
         assert(idx_ <= chunk_size);
-        ::new (reinterpret_cast<value_type*>(chunkList_[chunk_]) + idx_) value_type(v);
+        ::new (reinterpret_cast<value_type*>(chunkList_[chunk_ + (idx_ / chunk_size)]) + (idx_ % chunk_size)) value_type(v);
         ++idx_;
     }
 

--- a/src/XAD/ChunkContainer.hpp
+++ b/src/XAD/ChunkContainer.hpp
@@ -237,7 +237,6 @@ class ChunkContainer
 
     void push_back_reserved(const_reference v)
     {
-        assert(idx_ < chunk_size);
         ::new (reinterpret_cast<value_type*>(chunkList_[chunk_ + (idx_ / chunk_size)]) +
                (idx_ % chunk_size)) value_type(v);
         ++idx_;

--- a/src/XAD/ChunkContainer.hpp
+++ b/src/XAD/ChunkContainer.hpp
@@ -31,8 +31,8 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
-#include <vector>
 #include <memory>
+#include <vector>
 
 // cross-platform aligned (de-)allocation
 
@@ -238,7 +238,8 @@ class ChunkContainer
     void push_back_reserved(const_reference v)
     {
         assert(idx_ <= chunk_size);
-        ::new (reinterpret_cast<value_type*>(chunkList_[chunk_ + (idx_ / chunk_size)]) + (idx_ % chunk_size)) value_type(v);
+        ::new (reinterpret_cast<value_type*>(chunkList_[chunk_ + (idx_ / chunk_size)]) +
+               (idx_ % chunk_size)) value_type(v);
         ++idx_;
     }
 

--- a/src/XAD/Literals.hpp
+++ b/src/XAD/Literals.hpp
@@ -385,6 +385,7 @@ XAD_INLINE AReal<Scalar>& AReal<Scalar>::operator=(const Expression<Scalar, Expr
     if (expr.shouldRecord() || this->shouldRecord())
     {
         tape_type* s = tape_type::getActive();
+        s->reserve_for_expr(ExprTraits<Expr>().numVariables);
         expr.calc_derivatives(*s);
         // only register this variable after evaluating the expression, as this
         // variable might appear on the rhs of the equation too and if not yet

--- a/src/XAD/Tape.hpp
+++ b/src/XAD/Tape.hpp
@@ -224,7 +224,7 @@ class Tape
     void pushRhs(const Real& multiplier, slot_type slot);
     void pushRhs(Real&& multiplier, slot_type slot);
     void pushLhs(slot_type slot);
-    void pushAll(slot_type lhs,  std::pair<Real, slot_type>* mults_slots, unsigned n);
+    void pushAll(slot_type lhs, std::pair<Real, slot_type>* mults_slots, unsigned n);
 
     // capacity
     size_type getNumVariables() const;
@@ -315,14 +315,14 @@ template <class T>
 XAD_INLINE void Tape<T>::pushRhs(const T& multiplier, slot_type slot)
 {
     assert(slot != INVALID_SLOT);
-    mult_slot_.push_back_reserved(std::pair<T, slot_type >(multiplier, slot));
+    mult_slot_.push_back_reserved(std::pair<T, slot_type>(multiplier, slot));
 }
 
 template <class T>
 XAD_INLINE void Tape<T>::pushRhs(T&& multiplier, slot_type slot)
 {
     assert(slot != INVALID_SLOT);
-    mult_slot_.push_back_reserved(std::pair<T, slot_type >(multiplier, slot));
+    mult_slot_.push_back_reserved(std::pair<T, slot_type>(multiplier, slot));
 }
 
 template <class T>
@@ -333,7 +333,7 @@ XAD_INLINE void Tape<T>::pushLhs(slot_type slot)
 }
 
 template <class T>
-XAD_INLINE void Tape<T>::pushAll(slot_type lhs,  std::pair<T, slot_type>* mults_slots, unsigned n)
+XAD_INLINE void Tape<T>::pushAll(slot_type lhs, std::pair<T, slot_type>* mults_slots, unsigned n)
 {
     mult_slot_.append(mults_slots, mults_slots + n);
     pushLhs(lhs);

--- a/src/XAD/Tape.hpp
+++ b/src/XAD/Tape.hpp
@@ -224,7 +224,7 @@ class Tape
     void pushRhs(const Real& multiplier, slot_type slot);
     void pushRhs(Real&& multiplier, slot_type slot);
     void pushLhs(slot_type slot);
-    void pushAll(slot_type lhs, Real* multipliers, slot_type* slots, unsigned n);
+    void pushAll(slot_type lhs,  std::pair<Real, slot_type>* mults_slots, unsigned n);
 
     // capacity
     size_type getNumVariables() const;
@@ -259,8 +259,7 @@ class Tape
     }
 
     static XAD_THREAD_LOCAL Tape* active_tape_;
-    typename TapeContainerTraits<Real>::type multiplier_;
-    TapeContainerTraits<slot_type>::type slot_;
+    typename TapeContainerTraits<std::pair<Real, slot_type> >::type mult_slot_;
     TapeContainerTraits<std::pair<slot_type, slot_type> >::type statement_;
     std::vector<Real> derivatives_;
     typedef std::pair<position_type, CheckpointCallback<Tape>*> chkpt_type;
@@ -316,30 +315,27 @@ template <class T>
 XAD_INLINE void Tape<T>::pushRhs(const T& multiplier, slot_type slot)
 {
     assert(slot != INVALID_SLOT);
-    multiplier_.push_back_reserved(multiplier);
-    slot_.push_back_reserved(slot);
+    mult_slot_.push_back_reserved(std::pair<T, slot_type >(multiplier, slot));
 }
 
 template <class T>
 XAD_INLINE void Tape<T>::pushRhs(T&& multiplier, slot_type slot)
 {
     assert(slot != INVALID_SLOT);
-    multiplier_.push_back_reserved(std::move(multiplier));
-    slot_.push_back_reserved(slot);
+    mult_slot_.push_back_reserved(std::pair<T, slot_type >(multiplier, slot));
 }
 
 template <class T>
 XAD_INLINE void Tape<T>::pushLhs(slot_type slot)
 {
     assert(slot != INVALID_SLOT);
-    statement_.push_back_reserved(std::make_pair(size_type(slot_.size()), slot));
+    statement_.push_back_reserved(std::make_pair(size_type(mult_slot_.size()), slot));
 }
 
 template <class T>
-XAD_INLINE void Tape<T>::pushAll(slot_type lhs, T* multipliers, slot_type* slots, unsigned n)
+XAD_INLINE void Tape<T>::pushAll(slot_type lhs,  std::pair<T, slot_type>* mults_slots, unsigned n)
 {
-    multiplier_.append(multipliers, multipliers + n);
-    slot_.append(slots, slots + n);
+    mult_slot_.append(mults_slots, mults_slots + n);
     pushLhs(lhs);
 }
 

--- a/src/XAD/Tape.hpp
+++ b/src/XAD/Tape.hpp
@@ -244,6 +244,9 @@ class Tape
     // roll back the adjoints just to the given position (not to the start)
     void computeAdjointsTo(position_type pos);
 
+    // reserve enough on chunk for evaluating an expression
+    void reserve_for_expr(size_type numVariables);
+
   private:
     void computeAdjointsToImpl(position_type pos, position_type start);
     void initDerivatives();
@@ -313,23 +316,23 @@ template <class T>
 XAD_INLINE void Tape<T>::pushRhs(const T& multiplier, slot_type slot)
 {
     assert(slot != INVALID_SLOT);
-    multiplier_.push_back(multiplier);
-    slot_.push_back(slot);
+    multiplier_.push_back_reserved(multiplier);
+    slot_.push_back_reserved(slot);
 }
 
 template <class T>
 XAD_INLINE void Tape<T>::pushRhs(T&& multiplier, slot_type slot)
 {
     assert(slot != INVALID_SLOT);
-    multiplier_.push_back(std::move(multiplier));
-    slot_.push_back(slot);
+    multiplier_.push_back_reserved(std::move(multiplier));
+    slot_.push_back_reserved(slot);
 }
 
 template <class T>
 XAD_INLINE void Tape<T>::pushLhs(slot_type slot)
 {
     assert(slot != INVALID_SLOT);
-    statement_.push_back(std::make_pair(size_type(slot_.size()), slot));
+    statement_.push_back_reserved(std::make_pair(size_type(slot_.size()), slot));
 }
 
 template <class T>

--- a/src/XAD/Traits.hpp
+++ b/src/XAD/Traits.hpp
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 namespace xad
 {
 
@@ -38,7 +40,7 @@ template <class T>
 struct ExprTraits
 {
     static const bool isExpr = false;
-    static const int numVariables = 0;
+    static const std::size_t numVariables = 0;
     static const bool isForward = false;
     static const bool isReverse = false;
     static const bool isLiteral = false;

--- a/test/ChunkContainer_test.cpp
+++ b/test/ChunkContainer_test.cpp
@@ -197,3 +197,18 @@ TEST(ChunkContainer, append)
 
     for (int i = 0; i < 18; ++i) EXPECT_THAT(chk[size_t(i)], Eq(i)) << "at " << i;
 }
+
+TEST(ChunkContainer, push_back_reserved)
+{
+    ChunkContainer<int, 8> chk;
+
+    size_t size = 16;
+
+    chk.reserve(size);
+
+    for (int i = 0; i < size; ++i) chk.push_back(i);
+
+    for (int i = 0; i < size; ++i) EXPECT_THAT(chk[size_t(i)], Eq(i)) << "at " << i;
+
+    EXPECT_THAT(chk.size(), Eq(size));
+}

--- a/test/ChunkContainer_test.cpp
+++ b/test/ChunkContainer_test.cpp
@@ -202,11 +202,11 @@ TEST(ChunkContainer, push_back_reserved)
 {
     ChunkContainer<int, 8> chk;
 
-    size_t size = 16;
+    size_t size = 19;
 
     chk.reserve(size);
 
-    for (int i = 0; i < size; ++i) chk.push_back(i);
+    for (int i = 0; i < size; ++i) chk.push_back_reserved(i);
 
     for (int i = 0; i < size; ++i) EXPECT_THAT(chk[size_t(i)], Eq(i)) << "at " << i;
 

--- a/test/TapeContainer_test.cpp
+++ b/test/TapeContainer_test.cpp
@@ -39,8 +39,8 @@ TEST(TapeContainer, basic)
     // we only require push_backs to be successful after reserving
     sc.reserve(2);
 
-    sc.push_back(2);
-    sc.push_back(3);
+    sc.push_back_reserved(2);
+    sc.push_back_reserved(3);
     EXPECT_EQ(2U, sc.size());
     EXPECT_FALSE(sc.empty());
     EXPECT_EQ(2, sc[0]);

--- a/test/Tape_test.cpp
+++ b/test/Tape_test.cpp
@@ -307,9 +307,13 @@ TEST(Tape, canPushCombined)
 
     s.newRecording();
     auto zs = s.registerVariable();
-    std::array<double, 3> mul = {{std::cos(x1), x2, x1}};
-    std::array<xad::Tape<double>::slot_type, 3> sl = {{x1s, x1s, x2s}};
-    s.pushAll(zs, mul.data(), sl.data(), 3);
+    std::array<std::pair<double, xad::Tape<double>::slot_type>, 3> mul_slot = {{
+            std::pair<double, xad::Tape<double>::slot_type>(std::cos(x1), x1s),
+            std::pair<double, xad::Tape<double>::slot_type>(x2, x1s),
+            std::pair<double, xad::Tape<double>::slot_type>(x1, x2s),
+        }};
+
+    s.pushAll(zs, mul_slot.data(), 3);
     s.setDerivative(zs, 1.0);
     s.computeAdjoints();
     EXPECT_DOUBLE_EQ(1.0, s.getDerivative(x1s));


### PR DESCRIPTION
# Description

This PR optimizes the automatic differentiation tape system in three key ways:

1. Pre-allocates memory for expressions to reduce allocation overhead
2. Combines multiplier and slot data into a single container for better cache performance  
3. Simplifies derivative calculations by using direct multiplication instead of FMA

The changes significantly improve memory usage and computational speed while maintaining correctness.

Testing shows performance improvements with no impact on accuracy.


## Type of change

- Performance improvement
