### PR TITLE
Fixes variable shadowing in tests + type conversion warnings

### DIFF
--- a/src/XAD/Jacobian.hpp
+++ b/src/XAD/Jacobian.hpp
@@ -113,7 +113,7 @@ void computeJacobian(const std::vector<FReal<T>> &vec,
     std::size_t domain = vec.size();
     std::size_t codomain = foo(v).size();
 
-    if (std::distance(first, last) != codomain)
+    if (static_cast<std::size_t>(std::distance(first, last)) != codomain)
         throw OutOfRange("Iterator not allocated enough space (codomain)");
 
     auto row = first;

--- a/test/Hessian_test.cpp
+++ b/test/Hessian_test.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-   Tests for hessian methods.
+   Tests for Hessian methods.
 
    This file is part of XAD, a comprehensive C++ library for
    automatic differentiation.
@@ -44,14 +44,14 @@ TEST(HessianTest, QuadraticForwardAdjoint)
 
     tape_type tape;
 
-    std::vector<AD> x = {3.0, 2.0};
+    std::vector<AD> input = {3.0, 2.0};
 
     // f(x) = x[0]^2 + x[1]^2
     auto foo = [](std::vector<AD> &x) -> AD { return x[0] * x[0] + x[1] * x[1]; };
 
     std::vector<std::vector<double>> expected_hessian = {{2.0, 0.0}, {0.0, 2.0}};
 
-    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(x, foo, &tape);
+    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(input, foo, &tape);
 
     for (unsigned int i = 0; i < expected_hessian.size(); i++)
         EXPECT_THAT(computed_hessian[i], Pointwise(DoubleEq(), expected_hessian[i]));
@@ -62,14 +62,14 @@ TEST(HessianTest, QuadraticForwardAdjointAutoTape)
     typedef xad::fwd_adj<double> mode;
     typedef mode::active_type AD;
 
-    std::vector<AD> x = {3.0, 2.0};
+    std::vector<AD> input = {3.0, 2.0};
 
     // f(x) = x[0]^2 + x[1]^2
     auto foo = [](std::vector<AD> &x) -> AD { return x[0] * x[0] + x[1] * x[1]; };
 
     std::vector<std::vector<double>> expected_hessian = {{2.0, 0.0}, {0.0, 2.0}};
 
-    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(x, foo);
+    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(input, foo);
 
     for (unsigned int i = 0; i < expected_hessian.size(); i++)
         EXPECT_THAT(computed_hessian[i], Pointwise(DoubleEq(), expected_hessian[i]));
@@ -83,14 +83,14 @@ TEST(HessianTest, QuadraticForwardAdjointFetchTape)
 
     tape_type tape;
 
-    std::vector<AD> x = {3.0, 2.0};
+    std::vector<AD> input = {3.0, 2.0};
 
     // f(x) = x[0]^2 + x[1]^2
     auto foo = [](std::vector<AD> &x) -> AD { return x[0] * x[0] + x[1] * x[1]; };
 
     std::vector<std::vector<double>> expected_hessian = {{2.0, 0.0}, {0.0, 2.0}};
 
-    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(x, foo);
+    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(input, foo);
 
     for (unsigned int i = 0; i < expected_hessian.size(); i++)
         EXPECT_THAT(computed_hessian[i], Pointwise(DoubleEq(), expected_hessian[i]));
@@ -104,15 +104,15 @@ TEST(HessianTest, QuadraticForwardAdjointWithIterator)
 
     tape_type tape;
 
-    std::vector<AD> x = {3.0, 2.0};
+    std::vector<AD> input = {3.0, 2.0};
 
     // f(x) = x[0]^2 + x[1]^2
     auto foo = [](std::vector<AD> &x) -> AD { return x[0] * x[0] + x[1] * x[1]; };
 
     std::list<std::list<double>> expected_hessian = {{2.0, 0.0}, {0.0, 2.0}};
 
-    std::list<std::list<double>> computed_hessian(x.size(), std::list<double>(x.size(), 0.0));
-    xad::computeHessian<decltype(begin(computed_hessian)), double>(x, foo, begin(computed_hessian),
+    std::list<std::list<double>> computed_hessian(input.size(), std::list<double>(input.size(), 0.0));
+    xad::computeHessian<decltype(begin(computed_hessian)), double>(input, foo, begin(computed_hessian),
                                                                    end(computed_hessian), &tape);
 
     auto expected_it = expected_hessian.begin();
@@ -130,14 +130,14 @@ TEST(HessianTest, SingleInputForwardAdjoint)
 
     tape_type tape;
 
-    std::vector<AD> x = {3.0};
+    std::vector<AD> input = {3.0};
 
     // f(x) = x[0]^3 + x[0]
     auto foo = [](std::vector<AD> &x) -> AD { return x[0] * x[0] * x[0] + x[0]; };
 
     std::vector<std::vector<double>> expected_hessian = {{18.0}};
 
-    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(x, foo, &tape);
+    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(input, foo, &tape);
 
     for (unsigned int i = 0; i < expected_hessian.size(); i++)
         EXPECT_THAT(computed_hessian[i], Pointwise(DoubleEq(), expected_hessian[i]));
@@ -148,7 +148,7 @@ TEST(HessianTest, QuadraticForwardForward)
     typedef xad::fwd_fwd<double> mode;
     typedef mode::active_type AD;
 
-    std::vector<AD> x = {3.0, 2.0};
+    std::vector<AD> input = {3.0, 2.0};
 
     // f(x) = x[0]^2 + x[1]^2
     auto foo = [](std::vector<AD> &x) -> AD { return x[0] * x[0] + x[1] * x[1]; };
@@ -156,7 +156,7 @@ TEST(HessianTest, QuadraticForwardForward)
     std::vector<std::vector<double>> expected_hessian = {{2.0, 0.0},  //
                                                          {0.0, 2.0}};
 
-    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(x, foo);
+    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(input, foo);
 
     for (unsigned int i = 0; i < expected_hessian.size(); i++)
         EXPECT_THAT(computed_hessian[i], Pointwise(DoubleEq(), expected_hessian[i]));
@@ -167,7 +167,7 @@ TEST(HessianTest, QuadraticForwardForwardWithIterator)
     typedef xad::fwd_fwd<double> mode;
     typedef mode::active_type AD;
 
-    std::vector<AD> x = {3.0, 2.0};
+    std::vector<AD> input = {3.0, 2.0};
 
     // f(x) = x[0]^2 + x[1]^2
     auto foo = [](std::vector<AD> &x) -> AD { return x[0] * x[0] + x[1] * x[1]; };
@@ -175,8 +175,8 @@ TEST(HessianTest, QuadraticForwardForwardWithIterator)
     std::list<std::list<double>> expected_hessian = {{2.0, 0.0},  //
                                                      {0.0, 2.0}};
 
-    std::list<std::list<double>> computed_hessian(x.size(), std::list<double>(x.size(), 0.0));
-    xad::computeHessian<decltype(begin(computed_hessian)), double>(x, foo, begin(computed_hessian),
+    std::list<std::list<double>> computed_hessian(input.size(), std::list<double>(input.size(), 0.0));
+    xad::computeHessian<decltype(begin(computed_hessian)), double>(input, foo, begin(computed_hessian),
                                                                    end(computed_hessian));
 
     auto expected_it = expected_hessian.begin();
@@ -191,14 +191,14 @@ TEST(HessianTest, SingleInputForwardForward)
     typedef xad::fwd_fwd<double> mode;
     typedef mode::active_type AD;
 
-    std::vector<AD> x = {3.0};
+    std::vector<AD> input = {3.0};
 
     // f(x) = x[0]^3 + x[0]
     auto foo = [](std::vector<AD> &x) -> AD { return x[0] * x[0] * x[0] + x[0]; };
 
     std::vector<std::vector<double>> expected_hessian = {{18.0}};
 
-    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(x, foo);
+    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(input, foo);
 
     for (unsigned int i = 0; i < expected_hessian.size(); i++)
         EXPECT_THAT(computed_hessian[i], Pointwise(DoubleEq(), expected_hessian[i]));
@@ -212,7 +212,7 @@ TEST(HessianTest, QuadraticThreeVariablesForwardAdjoint)
 
     tape_type tape;
 
-    std::vector<AD> x = {1.0, 2.0, 3.0};
+    std::vector<AD> input = {1.0, 2.0, 3.0};
 
     // f(x) = x[0]^2 + x[1]^2 + x[2]^2
     auto foo = [](std::vector<AD> &x) -> AD { return x[0] * x[0] + x[1] * x[1] + x[2] * x[2]; };
@@ -220,7 +220,7 @@ TEST(HessianTest, QuadraticThreeVariablesForwardAdjoint)
     std::vector<std::vector<double>> expected_hessian = {
         {2.0, 0.0, 0.0}, {0.0, 2.0, 0.0}, {0.0, 0.0, 2.0}};
 
-    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(x, foo, &tape);
+    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(input, foo, &tape);
 
     for (unsigned int i = 0; i < expected_hessian.size(); i++)
         EXPECT_THAT(computed_hessian[i], Pointwise(DoubleEq(), expected_hessian[i]));
@@ -234,18 +234,18 @@ TEST(HessianTest, ComplexFunctionForwardAdjoint)
 
     tape_type tape;
 
-    std::vector<AD> x = {1.0, 2.0, 3.0, 4.0};
+    std::vector<AD> input = {1.0, 2.0, 3.0, 4.0};
 
     // f(x) = x[0] * sin(x[1]) + x[2] * exp(x[3])
     auto foo = [](std::vector<AD> &x) -> AD { return x[0] * sin(x[1]) + x[2] * exp(x[3]); };
 
     std::vector<std::vector<double>> expected_hessian = {
-        {0.0, cos(value(value(x[1]))), 0.0, 0.0},
-        {cos(value(value(x[1]))), -value(value(x[0])) * sin(value(value(x[1]))), 0.0, 0.0},
-        {0.0, 0.0, 0.0, exp(value(value(x[3])))},
-        {0.0, 0.0, exp(value(value(x[3]))), value(value(x[2])) * exp(value(value(x[3])))}};
+        {0.0, cos(value(value(input[1]))), 0.0, 0.0},
+        {cos(value(value(input[1]))), -value(value(input[0])) * sin(value(value(input[1]))), 0.0, 0.0},
+        {0.0, 0.0, 0.0, exp(value(value(input[3])))},
+        {0.0, 0.0, exp(value(value(input[3]))), value(value(input[2])) * exp(value(value(input[3])))}};
 
-    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(x, foo, &tape);
+    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(input, foo, &tape);
 
     for (unsigned int i = 0; i < expected_hessian.size(); i++)
         EXPECT_THAT(computed_hessian[i], Pointwise(DoubleEq(), expected_hessian[i]));
@@ -259,17 +259,17 @@ TEST(HessianTest, FourthOrderPolynomialForwardAdjoint)
 
     tape_type tape;
 
-    std::vector<AD> x = {1.0, 2.0, 3.0};
+    std::vector<AD> input = {1.0, 2.0, 3.0};
 
     // f(x) = x[0]^4 + x[1]^4 + x[2]^4
     auto foo = [](std::vector<AD> &x) -> AD { return pow(x[0], 4) + pow(x[1], 4) + pow(x[2], 4); };
 
     std::vector<std::vector<double>> expected_hessian = {
-        {12.0 * value(value(x[0])) * value(value(x[0])), 0.0, 0.0},
-        {0.0, 12.0 * value(value(x[1])) * value(value(x[1])), 0.0},
-        {0.0, 0.0, 12.0 * value(value(x[2])) * value(value(x[2]))}};
+        {12.0 * value(value(input[0])) * value(value(input[0])), 0.0, 0.0},
+        {0.0, 12.0 * value(value(input[1])) * value(value(input[1])), 0.0},
+        {0.0, 0.0, 12.0 * value(value(input[2])) * value(value(input[2]))}};
 
-    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(x, foo, &tape);
+    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(input, foo, &tape);
 
     for (unsigned int i = 0; i < expected_hessian.size(); i++)
         EXPECT_THAT(computed_hessian[i], Pointwise(DoubleEq(), expected_hessian[i]));
@@ -283,17 +283,17 @@ TEST(HessianTest, HigherOrderInteractionForwardAdjoint)
 
     tape_type tape;
 
-    std::vector<AD> x = {1.0, 2.0, 3.0};
+    std::vector<AD> input = {1.0, 2.0, 3.0};
 
     // f(x) = x[0] * x[1] * x[2]
     auto foo = [](std::vector<AD> &x) -> AD { return x[0] * x[1] * x[2]; };
 
     std::vector<std::vector<double>> expected_hessian = {
-        {0.0, value(value(x[2])), value(value(x[1]))},  //
-        {value(value(x[2])), 0.0, value(value(x[0]))},
-        {value(value(x[1])), value(value(x[0])), 0.0}};
+        {0.0, value(value(input[2])), value(value(input[1]))},  //
+        {value(value(input[2])), 0.0, value(value(input[0]))},
+        {value(value(input[1])), value(value(input[0])), 0.0}};
 
-    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(x, foo, &tape);
+    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(input, foo, &tape);
 
     for (unsigned int i = 0; i < expected_hessian.size(); i++)
         EXPECT_THAT(computed_hessian[i], Pointwise(DoubleEq(), expected_hessian[i]));
@@ -307,7 +307,7 @@ TEST(HessianTest, QuadraticFourVariablesForwardAdjoint)
 
     tape_type tape;
 
-    std::vector<AD> x = {1.0, 2.0, 3.0, 4.0};
+    std::vector<AD> input = {1.0, 2.0, 3.0, 4.0};
 
     // f(x) = x[0]^2 + x[1]^2 + x[2]^2 + x[3]^2
     auto foo = [](std::vector<AD> &x) -> AD
@@ -318,7 +318,7 @@ TEST(HessianTest, QuadraticFourVariablesForwardAdjoint)
                                                          {0.0, 0.0, 2.0, 0.0},
                                                          {0.0, 0.0, 0.0, 2.0}};
 
-    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(x, foo, &tape);
+    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(input, foo, &tape);
 
     for (unsigned int i = 0; i < expected_hessian.size(); i++)
         EXPECT_THAT(computed_hessian[i], Pointwise(DoubleEq(), expected_hessian[i]));
@@ -332,8 +332,8 @@ TEST(HessianTest, LargeHessianForwardAdjoint)
 
     tape_type tape;
 
-    std::vector<AD> x(16);
-    for (size_t i = 0; i < 16; ++i) x[i] = static_cast<double>(i + 1);
+    std::vector<AD> input(16);
+    for (size_t i = 0; i < 16; ++i) input[i] = static_cast<double>(i + 1);
 
     // f(x) = sum(x[i]^2) + sum(x[i] * x[j]), i < j
     auto foo = [](std::vector<AD> &x) -> AD
@@ -348,7 +348,7 @@ TEST(HessianTest, LargeHessianForwardAdjoint)
     std::vector<std::vector<double>> expected_hessian(16, std::vector<double>(16, 1.0));
     for (size_t i = 0; i < 16; ++i) expected_hessian[i][i] = 2.0;
 
-    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(x, foo, &tape);
+    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(input, foo, &tape);
 
     for (unsigned int i = 0; i < expected_hessian.size(); i++)
         EXPECT_THAT(computed_hessian[i], Pointwise(DoubleEq(), expected_hessian[i]));
@@ -359,8 +359,8 @@ TEST(HessianTest, LargeHessianForwardForward)
     typedef xad::fwd_fwd<double> mode;
     typedef mode::active_type AD;
 
-    std::vector<AD> x(16);
-    for (size_t i = 0; i < 16; ++i) x[i] = static_cast<double>(i + 1);
+    std::vector<AD> input(16);
+    for (size_t i = 0; i < 16; ++i) input[i] = static_cast<double>(i + 1);
 
     // f(x) = sum(x[i]^2) + sum(x[i] * x[j]), i < j
     auto foo = [](std::vector<AD> &x) -> AD
@@ -375,7 +375,7 @@ TEST(HessianTest, LargeHessianForwardForward)
     std::vector<std::vector<double>> expected_hessian(16, std::vector<double>(16, 1.0));
     for (size_t i = 0; i < 16; ++i) expected_hessian[i][i] = 2.0;
 
-    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(x, foo);
+    std::vector<std::vector<double>> computed_hessian = xad::computeHessian<double>(input, foo);
 
     for (unsigned int i = 0; i < expected_hessian.size(); i++)
         EXPECT_THAT(computed_hessian[i], Pointwise(DoubleEq(), expected_hessian[i]));
@@ -386,9 +386,9 @@ TEST(HessianTest, OutOfBoundsDomainSizeMismatch)
     typedef xad::fwd_adj<double> mode;
     typedef mode::active_type AD;
 
-    std::vector<AD> x = {1.0, 2.0};
+    std::vector<AD> input = {1.0, 2.0};
 
-    auto foo = [](std::vector<AD> &x) -> AD { return x[0]; };
+    auto func = [](std::vector<AD> &x) -> AD { return x[0]; };
 
     std::vector<std::vector<double>> jacobian(2, std::vector<double>(3));
 
@@ -403,5 +403,5 @@ TEST(HessianTest, OutOfBoundsDomainSizeMismatch)
         xad::computeHessian<RowIterator, double>(x, foo, first, last);
     };
 
-    EXPECT_THROW(launch(x, foo, begin(jacobian), end(jacobian)), xad::OutOfRange);
+    EXPECT_THROW(launch(input, func, begin(jacobian), end(jacobian)), xad::OutOfRange);
 }

--- a/test/Jacobian_test.cpp
+++ b/test/Jacobian_test.cpp
@@ -43,17 +43,17 @@ TEST(JacobianTest, SimpleAdjoint)
 
     tape_type tape;
 
-    std::vector<AD> x = {3.0, 1.0};
+    std::vector<AD> input = {3.0, 1.0};
 
     // f(x) = [ x[0] + sin(x[1]), x[1] + sin(x[0]) ]
     auto foo = [](std::vector<AD> &x) -> std::vector<AD>
     { return {x[0] + sin(x[1]), x[1] + sin(x[0])}; };
 
-    std::vector<std::vector<double>> expected_jacobian = {{1.0, cos(value(x[1]))},  //
-                                                          {cos(value(x[0])), 1.0}};
+    std::vector<std::vector<double>> expected_jacobian = {{1.0, cos(value(input[1]))},  //
+                                                          {cos(value(input[0])), 1.0}};
 
     std::vector<std::vector<double>> computed_jacobian =
-        xad::computeJacobian<double>(x, foo, &tape);
+        xad::computeJacobian<double>(input, foo, &tape);
 
     for (unsigned int i = 0; i < expected_jacobian.size(); i++)
         EXPECT_THAT(computed_jacobian[i], Pointwise(DoubleEq(), expected_jacobian[i]));
@@ -64,18 +64,18 @@ TEST(JacobianTest, SimpleAdjointIteratorAutoTape)
     typedef xad::adj<double> mode;
     typedef mode::active_type AD;
 
-    std::vector<AD> x = {3.0, 1.0};
+    std::vector<AD> input = {3.0, 1.0};
 
     // f(x) = [ x[0] + sin(x[1]), x[1] + sin(x[0]) ]
     auto foo = [](std::vector<AD> &x) -> std::vector<AD>
     { return {x[0] + sin(x[1]), x[1] + sin(x[0])}; };
 
-    std::list<std::list<double>> expected_jacobian = {{1.0, cos(value(x[1]))},  //
-                                                      {cos(value(x[0])), 1.0}};
+    std::list<std::list<double>> expected_jacobian = {{1.0, cos(value(input[1]))},  //
+                                                      {cos(value(input[0])), 1.0}};
 
     std::list<std::list<double>> computed_jacobian(2, std::list<double>(2, 0.0));
     xad::computeJacobian<decltype(begin(computed_jacobian)), double>(
-        x, foo, begin(computed_jacobian), end(computed_jacobian));
+        input, foo, begin(computed_jacobian), end(computed_jacobian));
 
     auto expected_it = expected_jacobian.begin();
     auto computed_it = computed_jacobian.begin();
@@ -92,18 +92,18 @@ TEST(JacobianTest, SimpleAdjointIteratorFetchTape)
 
     tape_type tape;
 
-    std::vector<AD> x = {3.0, 1.0};
+    std::vector<AD> input = {3.0, 1.0};
 
     // f(x) = [ x[0] + sin(x[1]), x[1] + sin(x[0]) ]
     auto foo = [](std::vector<AD> &x) -> std::vector<AD>
     { return {x[0] + sin(x[1]), x[1] + sin(x[0])}; };
 
-    std::list<std::list<double>> expected_jacobian = {{1.0, cos(value(x[1]))},  //
-                                                      {cos(value(x[0])), 1.0}};
+    std::list<std::list<double>> expected_jacobian = {{1.0, cos(value(input[1]))},  //
+                                                      {cos(value(input[0])), 1.0}};
 
     std::list<std::list<double>> computed_jacobian(2, std::list<double>(2, 0.0));
     xad::computeJacobian<decltype(begin(computed_jacobian)), double>(
-        x, foo, begin(computed_jacobian), end(computed_jacobian));
+        input, foo, begin(computed_jacobian), end(computed_jacobian));
 
     auto expected_it = expected_jacobian.begin();
     auto computed_it = computed_jacobian.begin();
@@ -117,16 +117,16 @@ TEST(JacobianTest, SimpleForward)
     typedef xad::fwd<double> mode;
     typedef mode::active_type AD;
 
-    std::vector<AD> x = {-2.0, 1.0};
+    std::vector<AD> input = {-2.0, 1.0};
 
     // f(x) = [ x[0] + sin(x[1]), x[1] + sin(x[0]) ]
     auto foo = [](std::vector<AD> &x) -> std::vector<AD>
     { return {x[0] + sin(x[1]), x[1] + sin(x[0])}; };
 
-    std::vector<std::vector<double>> expected_jacobian = {{1.0, cos(value(x[1]))},  //
-                                                          {cos(value(x[0])), 1.0}};
+    std::vector<std::vector<double>> expected_jacobian = {{1.0, cos(value(input[1]))},  //
+                                                          {cos(value(input[0])), 1.0}};
 
-    std::vector<std::vector<double>> computed_jacobian = xad::computeJacobian<double>(x, foo);
+    std::vector<std::vector<double>> computed_jacobian = xad::computeJacobian<double>(input, foo);
 
     for (unsigned int i = 0; i < expected_jacobian.size(); i++)
         EXPECT_THAT(computed_jacobian[i], Pointwise(DoubleEq(), expected_jacobian[i]));
@@ -137,18 +137,18 @@ TEST(JacobianTest, SimpleForwardIterator)
     typedef xad::fwd<double> mode;
     typedef mode::active_type AD;
 
-    std::vector<AD> x = {-2.0, 1.0};
+    std::vector<AD> input = {-2.0, 1.0};
 
     // f(x) = [ x[0] + sin(x[1]), x[1] + sin(x[0]) ]
     auto foo = [](std::vector<AD> &x) -> std::vector<AD>
     { return {x[0] + sin(x[1]), x[1] + sin(x[0])}; };
 
-    std::list<std::list<double>> expected_jacobian = {{1.0, cos(value(x[1]))},  //
-                                                      {cos(value(x[0])), 1.0}};
+    std::list<std::list<double>> expected_jacobian = {{1.0, cos(value(input[1]))},  //
+                                                      {cos(value(input[0])), 1.0}};
 
     std::list<std::list<double>> computed_jacobian(2, std::list<double>(2, 0.0));
     xad::computeJacobian<decltype(begin(computed_jacobian)), double>(
-        x, foo, begin(computed_jacobian), end(computed_jacobian));
+        input, foo, begin(computed_jacobian), end(computed_jacobian));
 
     auto expected_it = expected_jacobian.begin();
     auto computed_it = computed_jacobian.begin();
@@ -165,18 +165,18 @@ TEST(JacobianTest, ComplexFunctionAdjoint)
 
     tape_type tape;
 
-    std::vector<AD> x = {1.0, 2.0, 3.0, 4.0};
+    std::vector<AD> input = {1.0, 2.0, 3.0, 4.0};
 
     // f(x) = [ x[0] * x[1], x[2] * exp(x[3]) ]
     auto foo = [](std::vector<AD> &x) -> std::vector<AD>
     { return {x[0] * x[1], x[2] * exp(x[3])}; };
 
     std::vector<std::vector<double>> expected_jacobian = {
-        {value(x[1]), value(x[0]), 0.0, 0.0},
-        {0.0, 0.0, exp(value(x[3])), value(x[2]) * exp(value(x[3]))}};
+        {value(input[1]), value(input[0]), 0.0, 0.0},
+        {0.0, 0.0, exp(value(input[3])), value(input[2]) * exp(value(input[3]))}};
 
     std::vector<std::vector<double>> computed_jacobian =
-        xad::computeJacobian<double>(x, foo, &tape);
+        xad::computeJacobian<double>(input, foo, &tape);
 
     for (unsigned int i = 0; i < expected_jacobian.size(); i++)
         EXPECT_THAT(computed_jacobian[i], Pointwise(DoubleEq(), expected_jacobian[i]));
@@ -187,15 +187,15 @@ TEST(JacobianTest, DomainLargerThanCodomainForward)
     typedef xad::fwd<double> mode;
     typedef mode::active_type AD;
 
-    std::vector<AD> x = {1.0, 2.0, 3.0, 4.0};
+    std::vector<AD> input = {1.0, 2.0, 3.0, 4.0};
 
     // f(x) = [ x[0] + x[1], x[2] * x[3] ]
     auto foo = [](std::vector<AD> &x) -> std::vector<AD> { return {x[0] + x[1], x[2] * x[3]}; };
 
     std::vector<std::vector<double>> expected_jacobian = {{1.0, 1.0, 0.0, 0.0},  //
-                                                          {0.0, 0.0, value(x[3]), value(x[2])}};
+                                                          {0.0, 0.0, value(input[3]), value(input[2])}};
 
-    std::vector<std::vector<double>> computed_jacobian = xad::computeJacobian<double>(x, foo);
+    std::vector<std::vector<double>> computed_jacobian = xad::computeJacobian<double>(input, foo);
 
     for (unsigned int i = 0; i < expected_jacobian.size(); i++)
         EXPECT_THAT(computed_jacobian[i], Pointwise(DoubleEq(), expected_jacobian[i]));
@@ -206,15 +206,15 @@ TEST(JacobianTest, DomainLargerThanCodomainAdjoint)
     typedef xad::adj<double> mode;
     typedef mode::active_type AD;
 
-    std::vector<AD> x = {1.0, 2.0, 3.0, 4.0};
+    std::vector<AD> input = {1.0, 2.0, 3.0, 4.0};
 
     // f(x) = [ x[0] + x[1], x[2] * x[3] ]
     auto foo = [](std::vector<AD> &x) -> std::vector<AD> { return {x[0] + x[1], x[2] * x[3]}; };
 
     std::vector<std::vector<double>> expected_jacobian = {{1.0, 1.0, 0.0, 0.0},  //
-                                                          {0.0, 0.0, value(x[3]), value(x[2])}};
+                                                          {0.0, 0.0, value(input[3]), value(input[2])}};
 
-    std::vector<std::vector<double>> computed_jacobian = xad::computeJacobian<double>(x, foo);
+    std::vector<std::vector<double>> computed_jacobian = xad::computeJacobian<double>(input, foo);
 
     for (unsigned int i = 0; i < expected_jacobian.size(); i++)
         EXPECT_THAT(computed_jacobian[i], Pointwise(DoubleEq(), expected_jacobian[i]));
@@ -228,7 +228,7 @@ TEST(JacobianTest, DomainSmallerThanCodomainAdjoint)
 
     tape_type tape;
 
-    std::vector<AD> x = {2.0, 3.0};
+    std::vector<AD> input = {2.0, 3.0};
 
     // f(x) = [ x[0] + x[1], x[0] - x[1], x[0] * x[1] ]
     auto foo = [](std::vector<AD> &x) -> std::vector<AD>
@@ -236,10 +236,10 @@ TEST(JacobianTest, DomainSmallerThanCodomainAdjoint)
 
     std::vector<std::vector<double>> expected_jacobian = {{1.0, 1.0},  //
                                                           {1.0, -1.0},
-                                                          {value(x[1]), value(x[0])}};
+                                                          {value(input[1]), value(input[0])}};
 
     std::vector<std::vector<double>> computed_jacobian =
-        xad::computeJacobian<double>(x, foo, &tape);
+        xad::computeJacobian<double>(input, foo, &tape);
 
     for (unsigned int i = 0; i < expected_jacobian.size(); i++)
         EXPECT_THAT(computed_jacobian[i], Pointwise(DoubleEq(), expected_jacobian[i]));
@@ -250,19 +250,19 @@ TEST(JacobianTest, ComplexDomainNotEqualCodomainForwardIterator)
     typedef xad::fwd<double> mode;
     typedef mode::active_type AD;
 
-    std::vector<AD> x = {1.0, 2.0, 3.0};
+    std::vector<AD> input = {1.0, 2.0, 3.0};
 
     // f(x) = [ x[0] + x[1], x[1] * x[2], exp(x[0]) ]
     auto foo = [](std::vector<AD> &x) -> std::vector<AD>
     { return {x[0] + x[1], x[1] * x[2], exp(x[0])}; };
 
     std::list<std::list<double>> expected_jacobian = {{1.0, 1.0, 0.0},  //
-                                                      {0.0, value(x[2]), value(x[1])},
-                                                      {exp(value(x[0])), 0.0, 0.0}};
+                                                      {0.0, value(input[2]), value(input[1])},
+                                                      {exp(value(input[0])), 0.0, 0.0}};
 
     std::list<std::list<double>> computed_jacobian(3, std::list<double>(3, 0.0));
     xad::computeJacobian<decltype(begin(computed_jacobian)), double>(
-        x, foo, begin(computed_jacobian), end(computed_jacobian));
+        input, foo, begin(computed_jacobian), end(computed_jacobian));
 
     auto expected_it = expected_jacobian.begin();
     auto computed_it = computed_jacobian.begin();
@@ -276,15 +276,15 @@ TEST(JacobianTest, TrigonometricFunctionForward)
     typedef xad::fwd<double> mode;
     typedef mode::active_type AD;
 
-    std::vector<AD> x = {M_PI / 4, M_PI / 3};
+    std::vector<AD> input = {M_PI / 4, M_PI / 3};
 
     // f(x) = [ sin(x[0]), cos(x[1]) ]
     auto foo = [](std::vector<AD> &x) -> std::vector<AD> { return {sin(x[0]), cos(x[1])}; };
 
-    std::vector<std::vector<double>> expected_jacobian = {{cos(value(x[0])), 0.0},  //
-                                                          {0.0, -sin(value(x[1]))}};
+    std::vector<std::vector<double>> expected_jacobian = {{cos(value(input[0])), 0.0},  //
+                                                          {0.0, -sin(value(input[1]))}};
 
-    std::vector<std::vector<double>> computed_jacobian = xad::computeJacobian<double>(x, foo);
+    std::vector<std::vector<double>> computed_jacobian = xad::computeJacobian<double>(input, foo);
 
     for (unsigned int i = 0; i < expected_jacobian.size(); i++)
         EXPECT_THAT(computed_jacobian[i], Pointwise(DoubleEq(), expected_jacobian[i]));
@@ -295,15 +295,15 @@ TEST(JacobianTest, TrigonometricFunctionAdjointAutoTape)
     typedef xad::adj<double> mode;
     typedef mode::active_type AD;
 
-    std::vector<AD> x = {M_PI / 4, M_PI / 3};
+    std::vector<AD> input = {M_PI / 4, M_PI / 3};
 
     // f(x) = [ sin(x[0]), cos(x[1]) ]
     auto foo = [](std::vector<AD> &x) -> std::vector<AD> { return {sin(x[0]), cos(x[1])}; };
 
-    std::vector<std::vector<double>> expected_jacobian = {{cos(value(x[0])), 0.0},  //
-                                                          {0.0, -sin(value(x[1]))}};
+    std::vector<std::vector<double>> expected_jacobian = {{cos(value(input[0])), 0.0},  //
+                                                          {0.0, -sin(value(input[1]))}};
 
-    std::vector<std::vector<double>> computed_jacobian = xad::computeJacobian<double>(x, foo);
+    std::vector<std::vector<double>> computed_jacobian = xad::computeJacobian<double>(input, foo);
 
     for (unsigned int i = 0; i < expected_jacobian.size(); i++)
         EXPECT_THAT(computed_jacobian[i], Pointwise(DoubleEq(), expected_jacobian[i]));
@@ -314,9 +314,9 @@ TEST(JacobianTest, OutOfBoundsDomainSizeMismatch)
     typedef xad::adj<double> mode;
     typedef mode::active_type AD;
 
-    std::vector<AD> x = {1.0, 2.0};
+    std::vector<AD> input = {1.0, 2.0};
 
-    auto foo = [](std::vector<AD> &x) -> std::vector<AD> { return {x[0], x[1]}; };
+    auto func = [](std::vector<AD> &x) -> std::vector<AD> { return {x[0], x[1]}; };
 
     std::vector<std::vector<double>> jacobian(2, std::vector<double>(3));
 
@@ -330,7 +330,7 @@ TEST(JacobianTest, OutOfBoundsDomainSizeMismatch)
         xad::computeJacobian<RowIterator, double>(x, foo, first, last);
     };
 
-    EXPECT_THROW(launch(x, foo, begin(jacobian), end(jacobian)), xad::OutOfRange);
+    EXPECT_THROW(launch(input, func, begin(jacobian), end(jacobian)), xad::OutOfRange);
 }
 
 TEST(JacobianTest, OutOfBoundsCodomainSizeMismatch)
@@ -338,9 +338,9 @@ TEST(JacobianTest, OutOfBoundsCodomainSizeMismatch)
     typedef xad::adj<double> mode;
     typedef mode::active_type AD;
 
-    std::vector<AD> x = {1.0};
+    std::vector<AD> input = {1.0};
 
-    auto foo = [](std::vector<AD> &x) -> std::vector<AD> { return {x[0], x[0]}; };
+    auto func = [](std::vector<AD> &x) -> std::vector<AD> { return {x[0], x[0]}; };
 
     std::vector<std::vector<double>> jacobian(1, std::vector<double>(1));
 
@@ -354,5 +354,5 @@ TEST(JacobianTest, OutOfBoundsCodomainSizeMismatch)
         xad::computeJacobian<RowIterator, double>(x, foo, first, last);
     };
 
-    EXPECT_THROW(launch(x, foo, begin(jacobian), end(jacobian)), xad::OutOfRange);
+    EXPECT_THROW(launch(input, func, begin(jacobian), end(jacobian)), xad::OutOfRange);
 }


### PR DESCRIPTION
# Description

This fixes a set of warnings in XAD's Jacobian and Hessian code, flagged by GCC 12. It avoids shadowing variable names and does clean type conversions.

## Type of change

-   Bug fix (non-breaking change which fixes an issue)