### PR TITLE
QuantLib-Risks-Cpp CI Dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,7 +495,7 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           repository: raneamri/QuantLib-Risks-Cpp # auto-differentiation/QuantLib-Risks-Cpp
-          event-type: xad-ci-trigger
+          event-type: ql-risks-ci-trigger
           client-payload: >
             {
               "xad_repo": "${{ github.repository }}",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,13 +488,12 @@ jobs:
 
   trigger_quantlib_risks_cpp:
     name: Trigger QuantLib-Risks-Cpp CI
-    #needs: [build_and_test_windows, build_and_test_gcc, build_and_test_macos]
     runs-on: ubuntu-latest
     steps:
       - name: Trigger QuantLib-Risks-Cpp Workflow
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           repository: raneamri/QuantLib-Risks-Cpp # auto-differentiation/QuantLib-Risks-Cpp
           event-type: xad-ci-trigger
           client-payload: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,7 +495,7 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           repository: raneamri/QuantLib-Risks-Cpp # auto-differentiation/QuantLib-Risks-Cpp
-          event-type: ql-risks-ci-trigger
+          event-type: xad-ci-trigger
           client-payload: >
             {
               "xad_repo": "${{ github.repository }}",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,6 +486,23 @@ jobs:
             ${{ matrix.compiler == 'clang15' && ' -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++ -DCMAKE_C_COMPILER=clang' || '' }}
           cmake --build .
 
+  trigger_quantlib_risks_cpp:
+    name: Trigger QuantLib-Risks-Cpp CI
+    needs: [build_and_test_windows, build_and_test_gcc, build_and_test_macos]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger QuantLib-Risks-Cpp Workflow
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: raneamri/QuantLib-Risks-Cpp # auto-differentiation/QuantLib-Risks-Cpp
+          event-type: xad-ci-trigger
+          client-payload: >
+            {
+              "xad_repo": "${{ github.repository }}",
+              "xad_branch": "${{ github.ref_name }}"
+            }
+
   coverage_finish:
     name: Coverage Collect
     needs: [ build_and_test_gcc, build_and_test_macos]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,7 +488,7 @@ jobs:
 
   trigger_quantlib_risks_cpp:
     name: Trigger QuantLib-Risks-Cpp CI
-    needs: [build_and_test_windows, build_and_test_gcc, build_and_test_macos]
+    #needs: [build_and_test_windows, build_and_test_gcc, build_and_test_macos]
     runs-on: ubuntu-latest
     steps:
       - name: Trigger QuantLib-Risks-Cpp Workflow


### PR DESCRIPTION
# Description

Extension of `ci.yml` that triggers the workflows on the [QuantLib-Risks-Cpp](https://github.com/auto-differentiation/QuantLib-Risks-Cpp) workflow. An accompanying PR [#27](https://github.com/auto-differentiation/QuantLib-Risks-Cpp/pull/27) has been opened on the latter to listen for this repository dispatch. This feature is described in #156.

## Type of change

-   New feature (non-breaking change which adds functionality)