### PR TITLE
Adds std::fma math function support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolset: ["14.0", "14.1", "14.2", "14.4"]
+        toolset: ["14.1", "14.2", "14.4"]
         compiler: [msvc, clang]
         config: [Release, Debug]
         standard: ["11", "17"]
@@ -36,10 +36,6 @@ jobs:
             cc: cl
             os: windows-2022
             vsvarsall: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
-          - toolset: "14.0"
-            compiler: msvc
-            os: windows-2019
-            vsvarsall: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
           - toolset: "14.1"
             compiler: msvc
             os: windows-2019
@@ -49,8 +45,6 @@ jobs:
             toolset: "14.1"
           - compiler: clang
             toolset: "14.2"
-          - compiler: clang
-            toolset: "14.0"
           - config: Release
             memory: lowmem
           - compiler: clang

--- a/cmake/XADSetupOptions.cmake
+++ b/cmake/XADSetupOptions.cmake
@@ -63,12 +63,7 @@ endif()
 # Tape options: these end up in Config.hpp, a cmake-generated file
 option(XAD_TAPE_REUSE_SLOTS "Reuse slots in tape that have become free (slower, less memory)" OFF)
 option(XAD_NO_THREADLOCAL "Disable thread-local tape - only for single-threaded tape use" OFF)
-if (MSVC AND MSVC_VERSION GREATER_EQUAL 1910)
-    option(XAD_USE_STRONG_INLINE "Use forced inlining for higher performance, at a higher compile time cost" OFF)
-else()
-    # in VS 2015, without strong inlining, some long expressions in release mode get miscompiled
-    set(XAD_USE_STRONG_INLINE ON CACHE BOOL "Use forced inlining for higher preformance, at a higher compile time cost" FORCE)
-endif()
+option(XAD_USE_STRONG_INLINE "Use forced inlining for higher performance, at a higher compile time cost" OFF)
 option(XAD_ALLOW_INT_CONVERSION "Add real->int conversion operator, potentially missing to track dependencies" ON)
 option(XAD_REDUCED_MEMORY "Reduce memory required for tape, at a slight performance cost" OFF)
 

--- a/docs/ref/math.md
+++ b/docs/ref/math.md
@@ -7,14 +7,16 @@ This includes the active XAD types as well as the standard passive types.
 The functions listed here are defined in the `xad` namespace,
 and C++ ADL rules (argument-dependent lookup) typically find these functions
 automatically if they are applied to XAD types.
-However, for this the calls must be unqualified, i.e. without a namespace specifier.
+However, for this the calls must be unqualified, i.e. without a namespace
+specifier.
 
 Alternatively, fully qualified names work as usual (e.g. `#!c++ xad::sin(x)`),
 also for `#!c++ float` and `#!c++ double`.
 
 For convenience, if the header `XAD/StdCompatibility.hpp` is included,
 the XAD variables are imported into the `std` namespace,
-so that existing calls to `#!c++ std::sin` and similar functions are working as expected.
+so that existing calls to `#!c++ std::sin` and similar functions are working
+as expected.
 
 ## Absolute Values, Max, Min, and Rounding
 
@@ -37,7 +39,8 @@ Note that for well-defined second order derivative, this is implemented as
 #### `min`
 
 `#!c++ T min(T x, T y)` returns the minimum of `x` and `y`.
-Note that for well-defined second order derivative, this is implemented as `(x + y - abs(x-y)) / 2`.
+Note that for well-defined second order derivative, this is
+implemented as `(x + y - abs(x-y)) / 2`.
 
 #### `fmin`
 
@@ -66,50 +69,54 @@ infinite precision and rounded only once to fit the result type.
 
 #### `lround`
 
-`#!c++ long lround(T x)` is like `#!c++ round`, but converts the result to a `#!c++ long` type.
+`#!c++ long lround(T x)` is like `#!c++ round`, but converts the
+result to a `#!c++ long` type.
 
 #### `llround`
 
-`#!c++ long long llround(T x)` is like `#!c++ round`, but converts the result to a `#!c++ long long` type.
+`#!c++ long long llround(T x)` is like `#!c++ round`, but converts the
+result to a `#!c++ long long` type.
 
 #### `fmod`
 
 `#!c++ T fmod(T x, T y)` returns the floating-point remainder of the division
-operation `x/y`, i.e.exactly the value `x - n*y`, where `n` is `x/y` with its 
+operation `x/y`, i.e.exactly the value `x - n*y`, where `n` is `x/y` with its
 fractional part truncated.
 
 #### `remainder`
 
-`#!c++ T remainder(T x, T y)` calculates the IEEE floating-point remainder of the
-division operation `x/y`, i.e. exactly the value `x - n*y`, where the value `n` 
-is the integral value nearest the exact value `x/y`.
+`#!c++ T remainder(T x, T y)` calculates the IEEE floating-point
+remainder of the division operation `x/y`, i.e. exactly the value `x - n*y`,
+where the value `n` is the integral value nearest the exact value `x/y`.
 
 When `abs(n-x/y) = 0.5`, the value `n` is chosen to be even.
 
-In contrast to `#!c++ fmod`, the returned value is not guaranteed to have the same sign as `x`.
+In contrast to `#!c++ fmod`, the returned value is not guaranteed to have
+the same sign as `x`.
 
 #### `remquo`
 
-`#!c++ T remquo(T x, T y, int* n)` is the same as `#!c++ remainder`, but returns 
-the integer factor `n` in addition.
+`#!c++ T remquo(T x, T y, int* n)` is the same as `#!c++ remainder`, but
+returns the integer factor `n` in addition.
 
 #### `modf`
 
-`#!c++ T modf(T x, T* iptr)` decomposes `x` into integral and fractional parts, 
+`#!c++ T modf(T x, T* iptr)` decomposes `x` into integral and fractional parts,
 each with the same type and sign as `x`. The integral part is stored in `iptr`.
 
 #### `nextafter`
 
-`#!c++ T nextafter(T from, T to)` returns the next representable value of `from` 
+`#!c++ T nextafter(T from, T to)` returns the next representable value of `from`
 in the direction of `to`.
 
 Mathmatically, the difference of `from` to the return value is very small.
-For derivatives, we therefore consider them both the same and calculate derivative accordingly.
+For derivatives, we therefore consider them both the same and calculate
+derivative accordingly.
 
 #### `copysign`
 
-`#!c++ T copysign(T x, T y)` copies the sign of the floating point value `y` to 
-the value `x`, correctly treating positive/negative zero, NaN, and Inf values. 
+`#!c++ T copysign(T x, T y)` copies the sign of the floating point value `y` to
+the value `x`, correctly treating positive/negative zero, NaN, and Inf values.
 It uses the function `signbit` internally to determine the sign of `y`.
 
 ## Trigonometric Functions
@@ -148,7 +155,7 @@ It uses the function `signbit` internally to determine the sign of `y`.
 
 #### `atan2`
 
-`#!c++ T atan2(T x, T y)` computes the four-quadrant inverse tangent of 
+`#!c++ T atan2(T x, T y)` computes the four-quadrant inverse tangent of
 a point located at `(x, y)`.
 
 #### `sinh`
@@ -215,8 +222,8 @@ a point located at `(x, y)`.
 
 #### `hypot`
 
-`#!c++ T hypot(T x, T y)` computes `sqrt(x*x + y*y)` without undue overflow or underflow at
-intermediate stages of the computation.
+`#!c++ T hypot(T x, T y)` computes `sqrt(x*x + y*y)` without undue overflow
+or underflow at intermediate stages of the computation.
 
 #### `pow`
 
@@ -228,7 +235,7 @@ intermediate stages of the computation.
 
 #### `frexp`
 
-`#!c++ T frexp(T arg, int* exp)` decomposes the given floating point value 
+`#!c++ T frexp(T arg, int* exp)` decomposes the given floating point value
 arg into a normalised fraction and an integral power of two.
 
 #### `ilogb`
@@ -246,12 +253,12 @@ using `FLT_RADIX` as base for the log.
 
 #### `erf`
 
-`#!c++ T erf(T x)` computes the error function of `x`, if provided by the compiler's math
-library.
+`#!c++ T erf(T x)` computes the error function of `x`, if provided by the
+compiler's math library.
 
 #### `erfc`
 
-`#!c++ T erfc(T x)` computes the complementary error function of `x`, 
+`#!c++ T erfc(T x)` computes the complementary error function of `x`,
 if provided by the compiler's math library.
 
 ## Floating Point Classification
@@ -270,10 +277,10 @@ if provided by the compiler's math library.
 
 #### `signbit`
 
-`#!c++ bool signbit(T x)` returns true if `x` is negative and false otherwise. 
+`#!c++ bool signbit(T x)` returns true if `x` is negative and false otherwise.
 Also detects sign bit of zeros.
 
 #### `isnormal`
 
-`#!c++ bool isnormal(T x)` checks if the value is a normal floating point 
+`#!c++ bool isnormal(T x)` checks if the value is a normal floating point
 number, i.e. not zero, subnormal, infinite, or NaN.

--- a/docs/ref/math.md
+++ b/docs/ref/math.md
@@ -20,7 +20,8 @@ so that existing calls to `#!c++ std::sin` and similar functions are working as 
 
 #### `abs`
 
-`#!c++ T abs(T x)` computes the absolute value of `x`. Note that for defined second-order derivatives, this computes `#!c++ (x>0)-(x<0)`
+`#!c++ T abs(T x)` computes the absolute value of `x`.
+Note that for defined second-order derivatives, this computes `#!c++ (x>0)-(x<0)`
 
 #### `max`
 
@@ -35,7 +36,8 @@ Note that for well-defined second order derivative, this is implemented as
 
 #### `min`
 
-`#!c++ T min(T x, T y)` returns the minimum of `x` and `y`. Note that for well-defined second order derivative, this is implemented as `(x + y - abs(x-y)) / 2`.
+`#!c++ T min(T x, T y)` returns the minimum of `x` and `y`.
+Note that for well-defined second order derivative, this is implemented as `(x + y - abs(x-y)) / 2`.
 
 #### `fmin`
 
@@ -51,7 +53,8 @@ Note that for well-defined second order derivative, this is implemented as
 
 #### `fma`
 
-`#!c++ T fma(T x, T y, T z)` computes `x * y + z` as if to infinite precision and rounded only once to fit the result type.
+`#!c++ T fma(T x, T y, T z)` computes `x * y + z` as if to
+infinite precision and rounded only once to fit the result type.
 
 #### `trunc`
 
@@ -71,11 +74,15 @@ Note that for well-defined second order derivative, this is implemented as
 
 #### `fmod`
 
-`#!c++ T fmod(T x, T y)` returns the floating-point remainder of the division operation `x/y`, i.e.exactly the value `x - n*y`, where `n` is `x/y` with its fractional part truncated.
+`#!c++ T fmod(T x, T y)` returns the floating-point remainder of the division
+operation `x/y`, i.e.exactly the value `x - n*y`, where `n` is `x/y` with its 
+fractional part truncated.
 
 #### `remainder`
 
-`#!c++ T remainder(T x, T y)` calculates the IEEE floating-point remainder of the division operation `x/y`, i.e. exactly the value `x - n*y`, where the value `n` is the integral value nearest the exact value `x/y`.
+`#!c++ T remainder(T x, T y)` calculates the IEEE floating-point remainder of the
+division operation `x/y`, i.e. exactly the value `x - n*y`, where the value `n` 
+is the integral value nearest the exact value `x/y`.
 
 When `abs(n-x/y) = 0.5`, the value `n` is chosen to be even.
 
@@ -83,22 +90,27 @@ In contrast to `#!c++ fmod`, the returned value is not guaranteed to have the sa
 
 #### `remquo`
 
-`#!c++ T remquo(T x, T y, int* n)` is the same as `#!c++ remainder`, but returns the integer factor `n` in addition.
+`#!c++ T remquo(T x, T y, int* n)` is the same as `#!c++ remainder`, but returns 
+the integer factor `n` in addition.
 
 #### `modf`
 
-`#!c++ T modf(T x, T* iptr)` decomposes `x` into integral and fractional parts, each with the same type and sign as `x`. The integral part is stored in `iptr`.
+`#!c++ T modf(T x, T* iptr)` decomposes `x` into integral and fractional parts, 
+each with the same type and sign as `x`. The integral part is stored in `iptr`.
 
 #### `nextafter`
 
-`#!c++ T nextafter(T from, T to)` returns the next representable value of `from` in the direction of `to`.
+`#!c++ T nextafter(T from, T to)` returns the next representable value of `from` 
+in the direction of `to`.
 
 Mathmatically, the difference of `from` to the return value is very small.
 For derivatives, we therefore consider them both the same and calculate derivative accordingly.
 
 #### `copysign`
 
-`#!c++ T copysign(T x, T y)` copies the sign of the floating point value `y` to the value `x`, correctly treating positive/negative zero, NaN, and Inf values. It uses the function `signbit` internally to determine the sign of `y`.
+`#!c++ T copysign(T x, T y)` copies the sign of the floating point value `y` to 
+the value `x`, correctly treating positive/negative zero, NaN, and Inf values. 
+It uses the function `signbit` internally to determine the sign of `y`.
 
 ## Trigonometric Functions
 
@@ -136,7 +148,8 @@ For derivatives, we therefore consider them both the same and calculate derivati
 
 #### `atan2`
 
-`#!c++ T atan2(T x, T y)` computes the four-quadrant inverse tangent of a point located at `(x, y)`.
+`#!c++ T atan2(T x, T y)` computes the four-quadrant inverse tangent of 
+a point located at `(x, y)`.
 
 #### `sinh`
 
@@ -202,7 +215,7 @@ For derivatives, we therefore consider them both the same and calculate derivati
 
 #### `hypot`
 
-`#!c++ T hypot(T x, T y)` computes `sqrt(x*x + y*y)` without undue overflow or underflow at 
+`#!c++ T hypot(T x, T y)` computes `sqrt(x*x + y*y)` without undue overflow or underflow at
 intermediate stages of the computation.
 
 #### `pow`
@@ -215,7 +228,8 @@ intermediate stages of the computation.
 
 #### `frexp`
 
-`#!c++ T frexp(T arg, int* exp)` decomposes the given floating point value arg into a normalised fraction and an integral power of two.
+`#!c++ T frexp(T arg, int* exp)` decomposes the given floating point value 
+arg into a normalised fraction and an integral power of two.
 
 #### `ilogb`
 
@@ -228,7 +242,7 @@ using `FLT_RADIX` as base for the log.
 
 ## Error Functions
 
-***
+---
 
 #### `erf`
 
@@ -237,7 +251,8 @@ library.
 
 #### `erfc`
 
-`#!c++ T erfc(T x)` computes the complementary error function of `x`, if provided by the compiler's math library.
+`#!c++ T erfc(T x)` computes the complementary error function of `x`, 
+if provided by the compiler's math library.
 
 ## Floating Point Classification
 
@@ -255,8 +270,10 @@ library.
 
 #### `signbit`
 
-`#!c++ bool signbit(T x)` returns true if `x` is negative and false otherwise. Also detects sign bit of zeros.
+`#!c++ bool signbit(T x)` returns true if `x` is negative and false otherwise. 
+Also detects sign bit of zeros.
 
 #### `isnormal`
 
-`#!c++ bool isnormal(T x)` checks if the value is a normal floating point number, i.e. not zero, subnormal, infinite, or NaN.
+`#!c++ bool isnormal(T x)` checks if the value is a normal floating point 
+number, i.e. not zero, subnormal, infinite, or NaN.

--- a/docs/ref/math.md
+++ b/docs/ref/math.md
@@ -49,6 +49,10 @@ Note that for well-defined second order derivative, this is implemented as
 
 `#!c++ T ceil(T x)` rounds towards positive infinity.
 
+#### `fma`
+
+`#!c++ T fma(T x, T y, T z)` computes `x * y + z` as if to infinite precision and rounded only once to fit the result type.
+
 #### `trunc`
 
 `#!c++ T trunc(T x)` rounds towards 0.

--- a/src/XAD/BinaryOperators.hpp
+++ b/src/XAD/BinaryOperators.hpp
@@ -73,6 +73,21 @@ XAD_INLINE auto smooth_min(const T1& x, const T2& y) -> decltype(0.5 * (x + y - 
     return 0.5 * (x + y - smooth_abs(x - y));
 }
 
+template <class T, class = typename std::enable_if<xad::ExprTraits<T>::isExpr>>
+XAD_INLINE auto fma(const T& a, const T& b, const T& c) -> decltype(a * b + c)
+{
+    return a * b + c;
+}
+
+template <
+    class T1, class T2, class T3,
+    class = typename std::enable_if<(xad::ExprTraits<T1>::isExpr || xad::ExprTraits<T2>::isExpr ||
+                                     xad::ExprTraits<T3>::isExpr)>>
+XAD_INLINE auto fma(const T1& a, const T2& b, const T3& c) -> decltype(a * b + c)
+{
+    return a * b + c;
+}
+
 /////////// comparisons - they just return bool
 
 #define XAD_COMPARE_OPERATOR(op)                                                                   \

--- a/src/XAD/OperationsContainer.hpp
+++ b/src/XAD/OperationsContainer.hpp
@@ -37,7 +37,6 @@ namespace xad
 namespace detail
 {
 
-
 #if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL
 // Make a checked iterator to avoid MSVC warnings.
 template <typename T>
@@ -59,7 +58,8 @@ inline T* make_checked(T* p, size_t)
 
 }  // namespace detail
 
-template <typename T, typename S, std::size_t ChunkSize = 1024U * 1024U * 8U, class AllocHelper = detail::AlignedAllocator>
+template <typename T, typename S, std::size_t ChunkSize = 1024U * 1024U * 8U,
+          class AllocHelper = detail::AlignedAllocator>
 class OperationsContainer
 {
   public:
@@ -284,7 +284,8 @@ class OperationsContainer
                 }
             }
 
-            if (end_idx == 0) {
+            if (end_idx == 0)
+            {
                 return;
             }
 
@@ -345,7 +346,8 @@ class OperationsContainer
             }
         }
 
-        if (end_idx == 0) {
+        if (end_idx == 0)
+        {
             return;
         }
         chk = mul_chunk(end_chunk);

--- a/src/XAD/OperationsContainerPaired.hpp
+++ b/src/XAD/OperationsContainerPaired.hpp
@@ -34,7 +34,8 @@
 namespace xad
 {
 
-template <typename T, typename S, std::size_t ChunkSize = 1024U * 1024U * 8U, class AllocHelper = detail::AlignedAllocator>
+template <typename T, typename S, std::size_t ChunkSize = 1024U * 1024U * 8U,
+          class AllocHelper = detail::AlignedAllocator>
 class OperationsContainerPaired
 {
   public:
@@ -177,7 +178,8 @@ class OperationsContainerPaired
             return;
 
         size_type e2 = end_idx;
-        if (e2 == 0) {
+        if (e2 == 0)
+        {
             return;
         }
         chk = chunk(end_chunk);
@@ -201,8 +203,8 @@ class OperationsContainerPaired
     {
         for (size_type i = 0; i < newChunks; ++i)
         {
-            auto chunk = AllocHelper::aligned_alloc(ALIGNMENT,
-                                               ChunkSize * sizeof(std::pair<mul_type, slot_type>));
+            auto chunk = AllocHelper::aligned_alloc(
+                ALIGNMENT, ChunkSize * sizeof(std::pair<mul_type, slot_type>));
             if (chunk == nullptr)
                 throw std::bad_alloc();
             chunks_.emplace_back(reinterpret_cast<char*>(chunk));
@@ -244,7 +246,8 @@ class OperationsContainerPaired
                 }
             }
 
-            if (end_idx == 0) {
+            if (end_idx == 0)
+            {
                 return;
             }
             chk = cont->chunk(end_chunk);
@@ -299,7 +302,8 @@ class OperationsContainerPaired
             }
         }
 
-        if (end_idx == 0) {
+        if (end_idx == 0)
+        {
             return;
         }
         chk = chunk(end_chunk);

--- a/src/XAD/StdCompatibility.hpp
+++ b/src/XAD/StdCompatibility.hpp
@@ -358,7 +358,7 @@ inline constexpr bool is_trivially_copyable_v<xad::FReal<xad::FReal<long double>
 
 // for MSVC, we need this workaround so that the safety checks in their STL
 // for floating point types are also passing for the XAD types
-#if (_MSC_VER > 1900)
+
 // VS 2017+, when the STL checks if a type is in the list of built-in floating point types,
 // this should forward the check to the wrapped type by AReal or FReal.
 //
@@ -425,24 +425,7 @@ _XAD_INLINE_VAR constexpr bool
 
 #undef _XAD_INLINE_VAR
 
-#else
-}
-#include <random>
-namespace std
-{
 
-// prior versions of MSVC (2015) use a different check
-template <class T>
-struct _Is_RealType<xad::AReal<T>> : public _Is_RealType<T>
-{
-};
-
-template <class T>
-struct _Is_RealType<xad::FReal<T>> : public _Is_RealType<T>
-{
-};
-
-#endif
 
 #endif
 

--- a/src/XAD/StdCompatibility.hpp
+++ b/src/XAD/StdCompatibility.hpp
@@ -28,7 +28,6 @@
 
 #pragma once
 
-
 #include <XAD/BinaryOperators.hpp>
 #include <XAD/Literals.hpp>
 #include <XAD/MathFunctions.hpp>
@@ -95,6 +94,7 @@ using xad::sqrt;
 using xad::tan;
 using xad::tanh;
 using xad::trunc;
+using xad::fma;
 
 #ifdef _MSC_VER
 // we need these explicit instantiation to disambiguate templates in MSVC

--- a/src/XAD/UnaryMathFunctors.hpp
+++ b/src/XAD/UnaryMathFunctors.hpp
@@ -430,7 +430,6 @@ struct scalar_remquo2_op
 
 /*
  * TODO:
-fma
 logb
 tgamma
 lgamma

--- a/src/XAD/UnaryMathFunctors.hpp
+++ b/src/XAD/UnaryMathFunctors.hpp
@@ -54,10 +54,7 @@ struct radians_op : scalar_prod_op<Scalar, Scalar>
     template <class Scalar>                                                                        \
     struct func##_op                                                                               \
     {                                                                                              \
-        XAD_INLINE Scalar operator()(const Scalar& a) const                                        \
-        {                                                                                          \
-            return func(a);                                                                        \
-        }                                                                                          \
+        XAD_INLINE Scalar operator()(const Scalar& a) const { return func(a); }                    \
         XAD_INLINE Scalar derivative(const Scalar& a) const                                        \
         {                                                                                          \
             XAD_UNUSED_VARIABLE(a);                                                                \
@@ -95,10 +92,7 @@ XAD_MAKE_UNARY_FUNCTOR(round, Scalar())
     template <class Scalar>                                                                        \
     struct func##_op                                                                               \
     {                                                                                              \
-        XAD_INLINE Scalar operator()(const Scalar& a) const                                        \
-        {                                                                                          \
-            return func(a);                                                                        \
-        }                                                                                          \
+        XAD_INLINE Scalar operator()(const Scalar& a) const { return func(a); }                    \
         XAD_INLINE Scalar derivative(const Scalar& a, const Scalar& v) const                       \
         {                                                                                          \
             XAD_UNUSED_VARIABLE(a);                                                                \
@@ -120,6 +114,7 @@ XAD_MAKE_UNARY_FUNCTOR_RES(sqrt, Scalar(0.5) / v)
 XAD_MAKE_UNARY_FUNCTOR_RES(cbrt, Scalar(1) / Scalar(3) / (v * v))
 
 // tangent
+
 template <class Scalar>
 struct tan_op
 {
@@ -141,13 +136,8 @@ struct fabs_op : abs_op<Scalar>
     template <class Scalar, class T2>                                                              \
     struct scalar_##func##2_op                                                                     \
     {                                                                                              \
-        XAD_INLINE explicit scalar_##func##2_op(const T2& b_t) : b(b_t)                            \
-        {                                                                                          \
-        }                                                                                          \
-        XAD_INLINE Scalar operator()(const Scalar& a) const                                        \
-        {                                                                                          \
-            return func(a, b);                                                                     \
-        }                                                                                          \
+        XAD_INLINE explicit scalar_##func##2_op(const T2& b_t) : b(b_t) {}                         \
+        XAD_INLINE Scalar operator()(const Scalar& a) const { return func(a, b); }                 \
         XAD_INLINE Scalar derivative(const Scalar& a, const Scalar& v) const                       \
         {                                                                                          \
             XAD_UNUSED_VARIABLE(a);                                                                \
@@ -159,13 +149,8 @@ struct fabs_op : abs_op<Scalar>
     template <class Scalar, class T2>                                                              \
     struct scalar_##func##1_op                                                                     \
     {                                                                                              \
-        XAD_INLINE explicit scalar_##func##1_op(const T2& b_t) : b(b_t)                            \
-        {                                                                                          \
-        }                                                                                          \
-        XAD_INLINE Scalar operator()(const Scalar& a) const                                        \
-        {                                                                                          \
-            return func(b, a);                                                                     \
-        }                                                                                          \
+        XAD_INLINE explicit scalar_##func##1_op(const T2& b_t) : b(b_t) {}                         \
+        XAD_INLINE Scalar operator()(const Scalar& a) const { return func(b, a); }                 \
         XAD_INLINE Scalar derivative(const Scalar& a, const Scalar& v) const                       \
         {                                                                                          \
             XAD_UNUSED_VARIABLE(a);                                                                \

--- a/test/StdCompatibility_test.cpp
+++ b/test/StdCompatibility_test.cpp
@@ -313,37 +313,6 @@ class StdCompatibilityConstexprTempl : public ::testing::Test
 
 typedef ::testing::Types<xad::FAD, xad::FReal<xad::FReal<double>>> constexpr_test_types;
 
-#if !(_MSC_VER && _MSC_VER <= 1900)  // VS 2015 doesn't implement constexpr objects correctly
-
-TYPED_TEST_SUITE(StdCompatibilityConstexprTempl, constexpr_test_types);
-
-TYPED_TEST(StdCompatibilityConstexprTempl, NumericLimitsConstexpr)
-{
-    constexpr TypeParam t_xx = 1.0;
-    constexpr TypeParam t_min = std::numeric_limits<TypeParam>::min();
-    constexpr TypeParam t_max = std::numeric_limits<TypeParam>::max();
-    constexpr TypeParam t_lowest = std::numeric_limits<TypeParam>::lowest();
-    constexpr TypeParam t_eps = std::numeric_limits<TypeParam>::epsilon();
-    constexpr TypeParam t_den = std::numeric_limits<TypeParam>::denorm_min();
-    constexpr TypeParam t_inf = std::numeric_limits<TypeParam>::infinity();
-    constexpr TypeParam t_nan = std::numeric_limits<TypeParam>::quiet_NaN();
-    constexpr TypeParam t_snan = std::numeric_limits<TypeParam>::signaling_NaN();
-    constexpr TypeParam t_round = std::numeric_limits<TypeParam>::round_error();
-
-    XAD_UNUSED_VARIABLE(t_xx);
-    XAD_UNUSED_VARIABLE(t_min);
-    XAD_UNUSED_VARIABLE(t_max);
-    XAD_UNUSED_VARIABLE(t_lowest);
-    XAD_UNUSED_VARIABLE(t_eps);
-    XAD_UNUSED_VARIABLE(t_den);
-    XAD_UNUSED_VARIABLE(t_inf);
-    XAD_UNUSED_VARIABLE(t_nan);
-    XAD_UNUSED_VARIABLE(t_snan);
-    XAD_UNUSED_VARIABLE(t_round);
-}
-
-#endif
-
 TEST(StdCompatibility, StdMinWithSizeWorks)
 {
     // this has been added as the call to hashtable_policy.h in GCC showed a failure with this,

--- a/test/StdCompatibility_test.cpp
+++ b/test/StdCompatibility_test.cpp
@@ -43,6 +43,8 @@ TEST(StdCompatibility, canUseStdMath)
     EXPECT_THAT(std::max(x, x).getValue(), DoubleNear(std::max(xd, xd), 1e-9));
     EXPECT_THAT(std::fmax(x, x).getValue(), DoubleNear(std::fmax(xd, xd), 1e-9));
 
+    EXPECT_THAT(std::fma(x, x, x).getValue(), DoubleNear(std::fma(xd, xd, xd), 1e-9));
+
     EXPECT_THAT(std::ceil(x).getValue(), DoubleNear(std::ceil(xd), 1e-9));
     EXPECT_THAT(std::floor(x).getValue(), DoubleNear(std::floor(xd), 1e-9));
     EXPECT_THAT(std::trunc(x).getValue(), DoubleNear(std::trunc(xd), 1e-9));
@@ -103,7 +105,6 @@ TEST(StdCompatibility, canUseStdMath)
     EXPECT_THAT(std::fpclassify(x), Eq(std::fpclassify(xd)));
     EXPECT_THAT(std::ilogb(x), Eq(std::ilogb(xd)));
     EXPECT_THAT(std::copysign(x, -x), Eq(std::copysign(xd, -xd)));
-
     // complex
     EXPECT_THAT(std::real(x).getValue(), DoubleNear(std::real(xd), 1e-9));
     EXPECT_THAT(std::imag(x).getValue(), DoubleNear(std::imag(xd), 1e-9));
@@ -238,7 +239,7 @@ TYPED_TEST(StdCompatibilityTempl, Hashing)
 }
 
 // https://github.com/auto-differentiation/xad/pull/164#issuecomment-2775730529
-#if !defined(_MSC_VER ) || _MSC_VER < 1941
+#if !defined(_MSC_VER) || _MSC_VER < 1941
 TYPED_TEST(StdCompatibilityTempl, Traits)
 {
     static_assert(std::is_floating_point<TypeParam>::value, "active real should be floating point");


### PR DESCRIPTION
# Description

This adds support for the `std::fma` function to XAD. It should also fix the latest builds with QuantLib, which started to use this function in their codebase.

It also drops Visual Studio 2015 support.

## Type of change

-   New feature (non-breaking change which adds functionality)