### PR TITLE
Check record flags before tape lookup in AReal hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reduced passive-mode overhead of `AReal`: constructors, assignments, and the
+  destructor now check the variable/expression record flags before the
+  thread-local active-tape lookup, so code using AD types without a tape
+  skips the TLS access on every operation
+
 ### Deprecated
 
 ### Removed

--- a/src/XAD/Literals.hpp
+++ b/src/XAD/Literals.hpp
@@ -212,25 +212,25 @@ struct AReal
 
     XAD_INLINE AReal(const AReal& o) : base_type(), slot_(INVALID_SLOT)
     {
-        if (auto* s = tape_type::getActive())
+        // check the slot before the thread-local tape lookup, so that copies
+        // of passive variables (the common case when no tape is recording)
+        // avoid the TLS access entirely
+        if (XAD_UNLIKELY(o.shouldRecord()))
         {
-            if (o.shouldRecord())
+            if (auto* s = tape_type::getActive())
             {
                 slot_ = s->registerVariable();
                 pushAll<1>(s, o);
                 s->pushLhs(slot_);
             }
-        }
 #ifdef XAD_ENABLE_JIT
-        else if (getActiveJit() != nullptr)
-        {
-            if (o.shouldRecord())
+            else if (getActiveJit() != nullptr)
             {
                 // Copy the slot directly - preserves JIT dependency chain
                 slot_ = o.slot_;
             }
-        }
 #endif
+        }
         this->a_ = o.getValue();
     }
 
@@ -254,8 +254,10 @@ struct AReal
 
     XAD_INLINE ~AReal()
     {
-        if (auto tape = tape_type::getActive())
-            if (slot_ != INVALID_SLOT)
+        // slot check first: passive variables (no tape ever active) skip the
+        // thread-local tape lookup entirely
+        if (XAD_UNLIKELY(slot_ != INVALID_SLOT))
+            if (auto tape = tape_type::getActive())
                 tape->unregisterVariable(slot_);
     }
 
@@ -264,9 +266,11 @@ struct AReal
     XAD_INLINE AReal& operator=(nested_type x)
     {
         this->a_ = x;
-        auto tape = tape_type::getActive();
-        if (tape && slot_ != INVALID_SLOT)
-            tape->pushLhs(slot_);
+        if (XAD_UNLIKELY(slot_ != INVALID_SLOT))
+        {
+            if (auto tape = tape_type::getActive())
+                tape->pushLhs(slot_);
+        }
         return *this;
     }
 
@@ -521,26 +525,25 @@ struct ADVar
 template <class Scalar, std::size_t M>
 XAD_INLINE AReal<Scalar, M>& AReal<Scalar, M>::operator=(const AReal& o)
 {
-    if (auto* s = tape_type::getActive())
+    // slot checks before the thread-local tape lookup, so that assignments
+    // between passive variables avoid the TLS access entirely
+    if (XAD_UNLIKELY(o.shouldRecord() || this->shouldRecord()))
     {
-        if (o.shouldRecord() || this->shouldRecord())
+        if (auto* s = tape_type::getActive())
         {
             if (slot_ == INVALID_SLOT)
                 slot_ = s->registerVariable();
             pushAll<1>(s, o);
             s->pushLhs(slot_);
         }
-    }
 #ifdef XAD_ENABLE_JIT
-    else if (getActiveJit() != nullptr)
-    {
-        if (o.shouldRecord() || this->shouldRecord())
+        else if (getActiveJit() != nullptr)
         {
             // Copy the slot directly - preserves JIT dependency chain
             slot_ = o.slot_;
         }
-    }
 #endif
+    }
     this->a_ = o.getValue();
     return *this;
 }
@@ -551,22 +554,23 @@ XAD_INLINE AReal<Scalar, M>::AReal(
     const Expression<Scalar, Expr, typename DerivativesTraits<Scalar, M>::type>& expr)
     : base_type(expr.getValue()), slot_(INVALID_SLOT)
 {
-    tape_type* s = tape_type::getActive();
-    if (s)
+    // check the expression's record flags before the thread-local tape
+    // lookup, so that purely passive expressions avoid the TLS access
+    if (XAD_UNLIKELY(expr.shouldRecord()))
     {
-        if (expr.shouldRecord())
+        if (tape_type* s = tape_type::getActive())
         {
             slot_ = s->registerVariable();
             pushAll<ExprTraits<Expr>::numVariables>(s, expr);
             s->pushLhs(slot_);
         }
-    }
 #ifdef XAD_ENABLE_JIT
-    else
-    {
-        this->tryRecordJitFromExprCtor(expr, std::integral_constant<bool, jit_supported>());
-    }
+        else
+        {
+            this->tryRecordJitFromExprCtor(expr, std::integral_constant<bool, jit_supported>());
+        }
 #endif
+    }
 }
 
 template <class Scalar, std::size_t M>
@@ -574,10 +578,11 @@ template <class Expr>
 XAD_INLINE AReal<Scalar, M>& AReal<Scalar, M>::operator=(
     const Expression<Scalar, Expr, typename DerivativesTraits<Scalar, M>::type>& expr)
 {
-    tape_type* s = tape_type::getActive();
-    if (s)
+    // check the record flags before the thread-local tape lookup, so that
+    // assignments of purely passive expressions avoid the TLS access
+    if (XAD_UNLIKELY(expr.shouldRecord() || this->shouldRecord()))
     {
-        if (expr.shouldRecord() || this->shouldRecord())
+        if (tape_type* s = tape_type::getActive())
         {
             pushAll<ExprTraits<Expr>::numVariables>(s, expr);
             // only register this variable after evaluating the expression, as this
@@ -587,13 +592,13 @@ XAD_INLINE AReal<Scalar, M>& AReal<Scalar, M>::operator=(
                 slot_ = s->registerVariable();
             s->pushLhs(slot_);
         }
-    }
 #ifdef XAD_ENABLE_JIT
-    else
-    {
-        this->tryRecordJitFromExprAssign(expr, std::integral_constant<bool, jit_supported>());
-    }
+        else
+        {
+            this->tryRecordJitFromExprAssign(expr, std::integral_constant<bool, jit_supported>());
+        }
 #endif
+    }
     this->a_ = expr.getValue();
     return *this;
 }

--- a/test/ARealPassive_test.cpp
+++ b/test/ARealPassive_test.cpp
@@ -1,0 +1,166 @@
+/*******************************************************************************
+
+   Unit tests for AReal passive-mode semantics (no tape, or unrecorded
+   variables while a tape is active). These pin down the behaviour of the
+   slot-before-tape-lookup fast paths in constructors, assignments, and the
+   destructor.
+
+   This file is part of XAD, a comprehensive C++ library for
+   automatic differentiation.
+
+   Copyright (C) 2010-2026 Xcelerit Computing Ltd.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published
+   by the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+******************************************************************************/
+
+#include <XAD/XAD.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+// no tape anywhere: copies, assignments, expressions, and destruction must
+// work on values alone and never mark anything for recording
+TEST(ARealPassive, valueSemanticsWithoutTape)
+{
+    ASSERT_EQ(nullptr, xad::Tape<double>::getActive());
+
+    xad::AD a(1.5);
+    xad::AD b(a);  // copy ctor
+    xad::AD c;
+    c = b;  // copy assignment
+    EXPECT_DOUBLE_EQ(1.5, c.getValue());
+    c = 2.0;  // scalar assignment
+    xad::AD d = a + b * c;  // expression ctor
+    d = d * 2.0 + a;        // expression assignment
+
+    EXPECT_DOUBLE_EQ(1.5, a.getValue());
+    EXPECT_DOUBLE_EQ(1.5, b.getValue());
+    EXPECT_DOUBLE_EQ(2.0, c.getValue());
+    EXPECT_DOUBLE_EQ(2.0 * (1.5 + 1.5 * 2.0) + 1.5, d.getValue());
+    EXPECT_FALSE(a.shouldRecord());
+    EXPECT_FALSE(b.shouldRecord());
+    EXPECT_FALSE(c.shouldRecord());
+    EXPECT_FALSE(d.shouldRecord());
+}
+
+// with a tape active, copies and expressions of unrecorded variables must
+// stay unrecorded
+TEST(ARealPassive, passiveOperandsStayPassiveWithActiveTape)
+{
+    xad::Tape<double> s;
+    xad::AD p1(1.0), p2(2.0);  // never registered
+
+    xad::AD c(p1);          // copy ctor, passive source
+    xad::AD e = p1 + p2;    // expression ctor, passive operands
+    xad::AD f;
+    f = p2;  // copy assignment, both passive
+    EXPECT_DOUBLE_EQ(2.0, f.getValue());
+    f = p1 * p2 + e;  // expression assignment, all passive
+
+    EXPECT_FALSE(c.shouldRecord());
+    EXPECT_FALSE(e.shouldRecord());
+    EXPECT_FALSE(f.shouldRecord());
+    EXPECT_DOUBLE_EQ(1.0, c.getValue());
+    EXPECT_DOUBLE_EQ(3.0, e.getValue());
+    EXPECT_DOUBLE_EQ(1.0 * 2.0 + 3.0, f.getValue());
+}
+
+// copies and expressions of recorded variables must record as before
+TEST(ARealPassive, recordedOperandsRecordWithActiveTape)
+{
+    xad::Tape<double> s;
+    xad::AD x(3.0);
+    s.registerInput(x);
+    s.newRecording();
+
+    xad::AD y(x);           // copy ctor of recorded variable
+    xad::AD z = x * 2.0;    // expression ctor with recorded operand
+    EXPECT_TRUE(y.shouldRecord());
+    EXPECT_TRUE(z.shouldRecord());
+
+    derivative(z) = 1.0;
+    s.computeAdjoints();
+    EXPECT_DOUBLE_EQ(2.0, derivative(x));
+}
+
+// overwriting a recorded variable with a passive value must clear its
+// dependency on the inputs (this exercises the this->shouldRecord() branch
+// of the assignment fast paths)
+TEST(ARealPassive, assigningPassiveValueToRecordedVariableBreaksDependency)
+{
+    xad::Tape<double> s;
+    xad::AD x(3.0);
+    s.registerInput(x);
+    s.newRecording();
+
+    xad::AD passive(7.0);
+
+    xad::AD y = x * 2.0;
+    y = passive;  // copy assignment, passive rhs onto recorded lhs
+    derivative(y) = 1.0;
+    s.computeAdjoints();
+    EXPECT_DOUBLE_EQ(0.0, derivative(x));
+    EXPECT_DOUBLE_EQ(7.0, y.getValue());
+
+    s.clearDerivatives();
+    xad::AD w = x * 2.0;
+    w = passive + 1.0;  // expression assignment, passive rhs onto recorded lhs
+    derivative(w) = 1.0;
+    s.computeAdjoints();
+    EXPECT_DOUBLE_EQ(0.0, derivative(x));
+    EXPECT_DOUBLE_EQ(8.0, w.getValue());
+
+    s.clearDerivatives();
+    xad::AD v = x * 2.0;
+    v = 5.0;  // scalar assignment onto recorded lhs
+    derivative(v) = 1.0;
+    s.computeAdjoints();
+    EXPECT_DOUBLE_EQ(0.0, derivative(x));
+    EXPECT_DOUBLE_EQ(5.0, v.getValue());
+}
+
+// destroying registered variables when the tape has been deactivated (or
+// destroyed) must be safe - the destructor checks the slot before the tape
+TEST(ARealPassive, destructionAfterTapeDeactivation)
+{
+    xad::AD* leaked = nullptr;
+    {
+        xad::Tape<double> s;
+        auto* x = new xad::AD(1.0);
+        s.registerInput(*x);
+        EXPECT_TRUE(x->shouldRecord());
+        s.deactivate();
+        delete x;  // slot valid, no active tape: must not crash
+        s.activate();
+        leaked = new xad::AD(2.0);
+        s.registerInput(*leaked);
+    }
+    // tape destroyed entirely; variable with a valid slot outlives it
+    EXPECT_EQ(nullptr, xad::Tape<double>::getActive());
+    delete leaked;  // must not crash
+}
+
+// containers of passive variables with an active tape: bulk copies and
+// destruction stay value-only
+TEST(ARealPassive, vectorOfPassiveVariablesWithActiveTape)
+{
+    xad::Tape<double> s;
+    std::vector<xad::AD> v(100, xad::AD(1.25));
+    std::vector<xad::AD> w = v;  // copy construct all elements
+    w.resize(150, xad::AD(2.5));
+    double sum = 0.0;
+    for (const auto& e : w) sum += e.getValue();
+    EXPECT_DOUBLE_EQ(100 * 1.25 + 50 * 2.5, sum);
+    for (const auto& e : w) EXPECT_FALSE(e.shouldRecord());
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ set(testfiles
     ChunkContainer_test.cpp
     TestHelpers.hpp
     Tape_test.cpp
+    ARealPassive_test.cpp
     Expressions_test.cpp
     ExpressionsConversion_test.cpp
     ExpressionMath1_test.cpp

--- a/test/JITGraphInterpreter_test.cpp
+++ b/test/JITGraphInterpreter_test.cpp
@@ -223,6 +223,63 @@ TEST(JITGraphInterpreter, adjointsForComplexExpression)
     EXPECT_NEAR(6.0, jit.getDerivative(y.getSlot()), 1e-10);
 }
 
+// Tape recording followed by JIT recording in the same scope must give
+// consistent, combinable results - a regression test for the recording
+// branches in AReal's constructors and assignments.
+TEST(JITGraphInterpreter, tapeThenJitCombinedGivesCorrectResult)
+{
+    using AD = xad::AReal<double, 1>;
+    const double x0 = 2.0, y0 = 3.0;
+
+    // phase 1: two operations on a tape, rollback, get derivatives
+    // v = x*y + x
+    double v0, dvdx, dvdy;
+    {
+        xad::Tape<double> tape;
+        AD x = x0, y = y0;
+        tape.registerInput(x);
+        tape.registerInput(y);
+        tape.newRecording();
+        AD u = x * y;
+        AD v = u + x;
+        tape.registerOutput(v);
+        derivative(v) = 1.0;
+        tape.computeAdjoints();
+        v0 = v.getValue();        // 8
+        dvdx = derivative(x);     // y + 1 = 4
+        dvdy = derivative(y);     // x = 2
+        EXPECT_DOUBLE_EQ(8.0, v0);
+        EXPECT_DOUBLE_EQ(4.0, dvdx);
+        EXPECT_DOUBLE_EQ(2.0, dvdy);
+    }
+    ASSERT_EQ(nullptr, xad::Tape<double>::getActive());
+
+    // phase 2: switch to JIT (interpreter backend) for two more operations
+    // r = a*a + a, evaluated at a = v0
+    double r0, drda;
+    {
+        xad::JITCompiler<double> jit;
+        AD a = v0;
+        jit.registerInput(a);
+        AD w = a * a;
+        AD r = w + a;
+        jit.registerOutput(r);
+        jit.compile();
+        jit.forward(&r0);
+        EXPECT_DOUBLE_EQ(v0 * v0 + v0, r0);  // 72
+        jit.setDerivative(r.getSlot(), 1.0);
+        jit.computeAdjoints();
+        drda = jit.getDerivative(a.getSlot());
+        EXPECT_NEAR(2.0 * v0 + 1.0, drda, 1e-10);  // 17
+    }
+    ASSERT_EQ(nullptr, xad::JITCompiler<double>::getActive());
+
+    // combine: f(x,y) = r(v(x,y)) - chain rule across the two recordings
+    EXPECT_NEAR((2.0 * v0 + 1.0) * dvdx, drda * dvdx, 1e-10);  // df/dx = 68
+    EXPECT_NEAR(68.0, drda * dvdx, 1e-10);
+    EXPECT_NEAR(34.0, drda * dvdy, 1e-10);  // df/dy
+}
+
 // =============================================================================
 // ABool tests
 // =============================================================================


### PR DESCRIPTION
Reorder checks so plain member reads gate the thread-local tape lookup, skipping the TLS access for passive variables. Recording behaviour is unchanged. Adds tests for the passive/recorded semantics of each path.