### PR TITLE
Fix compilation with libc++ 21

### DIFF
--- a/src/XAD/Literals.hpp
+++ b/src/XAD/Literals.hpp
@@ -842,7 +842,9 @@ typedef ARealDirect<float, 1> AFD;
 }  // namespace xad
 
 
-#if __clang_major__ > 16 && defined(_LIBCPP_VERSION)
+// libc++ 21 replaced the __promote class template with the SFINAE-friendly
+// alias __promote_t, which no longer needs (or allows) these specializations
+#if __clang_major__ > 16 && defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 210000
 
 namespace std {
 

--- a/src/XAD/StdCompatibility.hpp
+++ b/src/XAD/StdCompatibility.hpp
@@ -215,6 +215,15 @@ struct hash<xad::FReal<T, N>>
 };
 
 // type traits
+// libc++ 21 marks the standard type traits [[clang::no_specializations]],
+// which raises -Winvalid-specialization (a default-error warning) on the
+// specializations below; suppress it to keep behaviour identical across
+// standard libraries (libc++ internals use builtins, not the public traits)
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Winvalid-specialization"
+#endif
 template <class T, std::size_t N>
 struct is_floating_point<xad::AReal<T, N>> : std::is_floating_point<T>
 {
@@ -372,6 +381,10 @@ inline constexpr bool is_trivially_copyable_v<xad::FReal<xad::FReal<float>>> = t
 template <>
 inline constexpr bool is_trivially_copyable_v<xad::FReal<xad::FReal<long double>>> = true;
 
+#endif
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
 #endif
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
- Gate the `std::__promote` specializations to `_LIBCPP_VERSION < 210000`; libc++ 21 replaced the class with the non-specializable, SFINAE-friendly alias `__promote_t`.
- Suppress `-Winvalid-specialization` around the type trait specializations; libc++ 21 marks the traits `[[clang::no_specializations]]`.